### PR TITLE
Report webpack stats to packtracker.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ With GitHub Actions you can automate your workflow from idea to production.
 ### Community Resources
 
 - [Deploy a Node.js App to Azure](https://github.com/sdras/example-azure-node)
+- [Report webpack stats to packtracker.io](https://github.com/packtracker/github-action)
 
 ### Tutorials
 


### PR DESCRIPTION
This action allows users to report webpack build stats to the [packtracker.io](https://packtracker.io) service on push.

