### PR TITLE
Add link to send an SMS from github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ With GitHub Actions you can automate your workflow from idea to production.
 - [Deploy a Probot App using Actions](https://probot.github.io/docs/deployment/#github-actions)
 - [Deploy a playlist to Spotify](https://github.com/swinton/SpotHub)
 - [Use a Jenkinsfile](https://github.com/jonico/jenkinsfile-runner-github-actions)
+- [Send an SMS from GitHub Actions using Nexmo](https://github.com/nexmo-community/nexmo-sms-action)
 
 ### Tutorials
 


### PR DESCRIPTION
Adds the project page for Nexmo SMS github action. 
The page in turn has a tutorial. 