### PR TITLE
Added new Action to Declaratively setup GitHub labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Deploy VS Code extensions with vsce](https://github.com/lannonbr/vsce-action)
 - [Build a Jekyll site—with Custom Jekyll Plugins & Build Scripts—and deploy it back to the Gh-Pages Branch](https://github.com/BryanSchuetz/jekyll-deploy-gh-pages)
 - [Deploy a Cloudflare worker](https://github.com/cpilsworth/cloudflare-worker-action)
-
+- [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 
 ### Tutorials
 


### PR DESCRIPTION
Repo: https://github.com/lannonbr/issue-label-manager-action

This action is a way to define the labels for a GitHub repo inside
the repo itself. It runs a fairly small node app to see the diff of the
.github/labels.json file and will only update the various labels it needs
to. As well, currently it makes the labels in a repo match the json file,
so it will delete labels that are on the repo but not in json.