### PR TITLE
Add GitHub Action for Gatsby CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [GitHub Actions for Yarn](https://github.com/Borales/actions-yarn)
 - [Snyk CLI Test Action](https://github.com/clarkio/snyk-cli-action)
+- [GitHub Action for Gatsby CLI](https://github.com/jzweifel/gatsby-cli-github-action)
 
 
 ### Tutorials


### PR DESCRIPTION
This Action wraps the Gatsby CLI to enable common Gatsby commands.