### PR TITLE
adding organization and containertree github pages generator action

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
  - [Visualize your Dockerfile with a Container Tree](https://www.github.com/vsoch/containertree)
  - [Build Hugo static content site and publish it to gh-pages branch](https://github.com/khanhicetea/gh-actions-hugo-deploy-gh-pages)
  - [Build a Jekyll site—with Custom Jekyll Plugins & Build Scripts—and deploy it back to the Gh-Pages Branch](https://github.com/BryanSchuetz/jekyll-deploy-gh-pages)
+ - [Google Dataset Search Metadata](https://www.github.com/openschemas/extractors/): and other schema.org extractors to make datasets discoverable from GitHub pages.
 
 #### Notifications and Messages
 

--- a/README.md
+++ b/README.md
@@ -27,33 +27,43 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 
 ### Community Resources
 
-- [Deploy a Node.js App to Azure](https://github.com/sdras/example-azure-node)
 - [Use HashiCorp's Terraform](https://github.com/hashicorp/terraform-github-actions)
-- [Trigger emails with release notes with SendGrid](https://github.com/bitoiu/release-notify-action)
-- [Deploy to Netlify](https://github.com/netlify/actions)
 - [Home Assistant Command](https://github.com/maddox/actions/tree/master/home-assistant)
 - [Sleep](https://github.com/maddox/actions/tree/master/sleep)
 - [Wait for 200](https://github.com/maddox/actions/tree/master/wait-for-200)
-- [Deploy to any Cloud or Kubernetes Using Pulumi](https://github.com/pulumi/actions)
 - [Using surge.sh, deploy your branch specific storybook as a pull request deployment](https://github.com/codeship/storybook-surge-github-action)
-- [Report webpack stats to packtracker.io](https://github.com/packtracker/github-action)
-- [Deploy a Probot App using Actions](https://probot.github.io/docs/deployment/#github-actions)
-- [Deploy a playlist to Spotify](https://github.com/swinton/SpotHub)
 - [Use a Jenkinsfile](https://github.com/jonico/jenkinsfile-runner-github-actions)
 - [NPM Audit](https://github.com/JasonEtco/npm-audit-fix-action)
 - [Cleanup branches after merge](https://github.com/jessfraz/branch-cleanup-action)
-- [Post gif on check fail](https://github.com/jessfraz/shaking-finger-action)
-- [Send an SMS from GitHub Actions using Nexmo](https://github.com/nexmo-community/nexmo-sms-action)
-- [Send a Slack message](https://github.com/apex/actions/tree/master/slack)
 - [Node.js Actions Toolkit](https://github.com/JasonEtco/actions-toolkit)
-- [Deploy a Node.js function to AWS Lambda and invoke it using the Serverless framework](https://github.com/swinton/serverless)
-- [Deploy VS Code extensions with vsce](https://github.com/lannonbr/vsce-action)
-- [Build a Jekyll site—with Custom Jekyll Plugins & Build Scripts—and deploy it back to the Gh-Pages Branch](https://github.com/BryanSchuetz/jekyll-deploy-gh-pages)
-- [Deploy a Cloudflare worker](https://github.com/cpilsworth/cloudflare-worker-action)
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [GitHub Actions for Yarn](https://github.com/Borales/actions-yarn)
 - [Snyk CLI Test Action](https://github.com/clarkio/snyk-cli-action)
 
+#### Github Pages
+
+ - [Build a Jekyll site—with Custom Jekyll Plugins & Build Scripts—and deploy it back to the Gh-Pages Branch](https://github.com/BryanSchuetz/jekyll-deploy-gh-pages)
+ - [Visualize your Dockerfile with a Container Tree](https://www.github.com/vsoch/containertree)
+
+#### Deployment
+
+- [Deploy a Cloudflare worker](https://github.com/cpilsworth/cloudflare-worker-action)
+- [Deploy a Node.js App to Azure](https://github.com/sdras/example-azure-node)
+- [Deploy to Netlify](https://github.com/netlify/actions)
+- [Deploy to any Cloud or Kubernetes Using Pulumi](https://github.com/pulumi/actions)
+- [Deploy a Probot App using Actions](https://probot.github.io/docs/deployment/#github-actions)
+- [Deploy a playlist to Spotify](https://github.com/swinton/SpotHub)
+- [Deploy a Node.js function to AWS Lambda and invoke it using the Serverless framework](https://github.com/swinton/serverless)
+- [Deploy VS Code extensions with vsce](https://github.com/lannonbr/vsce-action)
+
+#### Notifications and Messages
+
+- [Post gif on check fail](https://github.com/jessfraz/shaking-finger-action)
+- [Send a Slack message](https://github.com/apex/actions/tree/master/slack)
+- [Send an SMS from GitHub Actions using Nexmo](https://github.com/nexmo-community/nexmo-sms-action)
+- [Confucious Wisdom (Pull Request Failure Message)](https://github.com/vsoch/confucious-actions)
+- [Report webpack stats to packtracker.io](https://github.com/packtracker/github-action)
+- [Trigger emails with release notes with SendGrid](https://github.com/bitoiu/release-notify-action)
 
 ### Tutorials
 


### PR DESCRIPTION
Hey @sdras ! Per your note in my first pull request, I've given a first shot at an organization for the actions below, note that my previously submit action (for the funny Confucius messages) is now under notifications and messages. The other categories are still fairly general, and I created based on what I saw in the list. This PR will also add the [containertree example](https://github.com/vsoch/containertree) that I put together yesterday, allowing a user to deploy an interactive tree diagram for their Dockerfile to Github pages.

I hope these are awesome enough!