### PR TITLE
Add Firebase resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Home Assistant Command](https://github.com/maddox/actions/tree/master/home-assistant)
 - [Sleep](https://github.com/maddox/actions/tree/master/sleep)
 - [Wait for 200](https://github.com/maddox/actions/tree/master/wait-for-200)
+- [Firebase](https://github.com/natemoo-re/action-firebase)
 - [Deploy to any Cloud or Kubernetes Using Pulumi](https://github.com/pulumi/actions)
 - [Using surge.sh, deploy your branch specific storybook as a pull request deployment](https://github.com/codeship/storybook-surge-github-action)
 - [Report webpack stats to packtracker.io](https://github.com/packtracker/github-action)
@@ -58,6 +59,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 ### Tutorials
 
 - [Introducing GitHub Actions](https://css-tricks.com/introducing-github-actions/)
+- [Deploying to Firebase Hosting with GitHub Actions](https://natemoo.re/posts/action-firebase)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information
 


### PR DESCRIPTION
- Links directly to [action-firebase](https://github.com/natemoo-re/action-firebase), which wraps the Firebase CLI.
- Adds tutorial on using action-firebase to [Deploy to Firebase Hosting](https://natemoo.re/posts/action-firebase/)