### PR TITLE
Add ember-cli-actions to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [GitHub Actions for Yarn](https://github.com/Borales/actions-yarn)
 - [Snyk CLI Test Action](https://github.com/clarkio/snyk-cli-action)
+- [Ember CLI Actions](https://github.com/NuckChorris/ember-cli-actions)
 
 
 ### Tutorials


### PR DESCRIPTION
Hey there, I created a small action to wrap ember-cli so that Ember apps can be built, tested, and deployed without ever leaving GitHub!