### PR TITLE
Add swinton/httpie-action: General purpose HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [GitHub Actions for Yarn](https://github.com/Borales/actions-yarn)
 - [Snyk CLI Test Action](https://github.com/clarkio/snyk-cli-action)
-
+- [General purpose HTTP client for Actions, wrapping HTTPie](https://github.com/swinton/httpie-action)
 
 ### Tutorials
 


### PR DESCRIPTION
From [the README](https://github.com/swinton/httpie-action/blob/master/README.md):

> A general purpose HTTP client for [**GitHub Actions**](https://developer.github.com/actions/), wrapping the [**HTTPie**](https://github.com/jakubroztocil/httpie) CLI to enable _human-friendly interactions with third-party web services_ that expose an API over HTTP in your [development workflow](https://developer.github.com/actions/creating-workflows/).
