### PR TITLE
Add deploy zola github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [GitHub Actions for Yarn](https://github.com/Borales/actions-yarn)
 - [Snyk CLI Test Action](https://github.com/clarkio/snyk-cli-action)
+- [Deploy a Zola site to GitHub Pages](https://github.com/shalzz/zola-deploy-action)
 
 
 ### Tutorials


### PR DESCRIPTION
This actions builds and deploys a [zola](https://github.com/getzola/zola) site to GitHub pages