### PR TITLE
Add link to linters and autofixers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [Build Hugo static content site and publish it to gh-pages branch](https://github.com/khanhicetea/gh-actions-hugo-deploy-gh-pages)
 
+### Collection of actions
+- [Many linters and autofixers for various languages../](https://github.com/bltavares/actions)
 
 ### Tutorials
 


### PR DESCRIPTION
This commit points to a quite alpha, but working set of linters. For linters which support autofixing issues, the actions are also capable of either automatically fixing on `push`, and or autofixing via Review comments.

So far, list list contains the following linters (and more to come):

| Action                       | Description                   | Lint on Push | Fix with Review   | Autofix on Push   |
|------------------------------|-------------------------------|--------------|-------------------|-------------------|
| cljfmt             | Clojure formatter             | x            | x                 | x                 |
| clippy             | Rust linter                   | x            | x (Partial fixes) | x (Partial fixes) |
| dartfmt           | Dart (and Flutter) formatter  | x            | x                 | x                 |
| pwshfmt           | Powershell Formatter          | x            | x                 | x                 |
| rubocop           | Ruby linter                   | x            | x                 | x                 |
| rustfmt           | Rust formatter                | x            | x                 | x                 |
| shfmt               | Shell formatter               | x            | x                 | x                 |
| tslint             | TypeScript lint and formatter | x            | x                 | x                 |
| dartanalyzer | Dart (and Flutter) linter     | x            |                   |                   |
| hadolint         | Dockerfile linter             | x            |                   |                   |
| kubeval           | Kubernets (k8s) linter        | x            |                   |                   |
| mdlint             | Markdown linting              | x            |                   |                   |
| shellcheck     | Bash linter                   | x            |                   |                   |


