### PR TITLE
Add action for setting PR reviewers based on assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 
 ### Community Resources
 
+- [Set pull request reviewers based on assignees](https://github.com/pullreminders/assignee-to-reviewer-action)
 - [Deploy a Node.js App to Azure](https://github.com/sdras/example-azure-node)
 - [Use HashiCorp's Terraform](https://github.com/hashicorp/terraform-github-actions)
 - [Trigger emails with release notes with SendGrid](https://github.com/bitoiu/release-notify-action)


### PR DESCRIPTION
The use case for this is that their team wants to switch to using review requests instead of assignees, but they were concerned about people on the team not wanting or being able to make the switch. This Action automatically mirrors review requests from assignees to make that transition easier!