### PR TITLE
Add link to Android GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [GitHub Action for Gatsby CLI](https://github.com/jzweifel/gatsby-cli-github-action)
 - [Send a Discord notification](https://github.com/Ilshidur/action-discord)
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
+- [Android Build and Emulator Actions](https://github.com/vgaidarji/android-github-actions)
+
 
 
 ### Tutorials


### PR DESCRIPTION
### What has been done
- Added link to repository with Android build and emulator actions
https://github.com/vgaidarji/android-github-actions
- PR on a sample project which uses those actions - https://github.com/vgaidarji/ci-matters/pull/26
- Blog post with some details about Android build & emulator actions http://vgaidarji.me/blog/2019/01/27/github-actions/