### PR TITLE
add jwr0/dockerfile-linter-action Dockerfile linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [GitHub Action for Gatsby CLI](https://github.com/jzweifel/gatsby-cli-github-action)
 - [Send a Discord notification](https://github.com/Ilshidur/action-discord)
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
+- [Lint a Dockerfile (using replicatedhq/dockerfilelint)](https://github.com/jwr0/dockerfile-linter-action)
 
 
 ### Tutorials


### PR DESCRIPTION
- Add jwr0/dockerfile-linter-action, which lints a Dockerfile and comments on a PR if any errors were found. The logic used in this action comes from replicatedhq/dockerfilelint, which is the same logic behind https://fromlatest.io