### PR TITLE
Add link to Android GitHub Actions blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Introducing GitHub Actions](https://css-tricks.com/introducing-github-actions/)
 - [Deploying to Firebase Hosting with GitHub Actions](https://natemoo.re/posts/action-firebase)
 - [Building GitHub Actions in Node.js](https://jasonet.co/posts/building-github-actions-in-node/)
+- [GitHub Actions on Android project](http://vgaidarji.me/blog/2019/01/27/github-actions)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information
 


### PR DESCRIPTION
### What has been done
Added a link to Android GitHub Actions blog post to `tutorials` section.
Follow up on https://github.com/sdras/awesome-actions/pull/69.