### PR TITLE
Add DNS Control GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Build Hugo static content site and publish it to gh-pages branch](https://github.com/khanhicetea/gh-actions-hugo-deploy-gh-pages)
 - [Deploy via rsync over ssh](https://github.com/maxheld83/ghaction-rsync)
 - [Test your Actions Locally](https://github.com/tschoffelen/gha)
+- [Deploy your DNS configuration using DNS Control](https://github.com/koenrh/dnscontrol-action)
 
 
 ### Collection of actions


### PR DESCRIPTION
This adds the DNS Control action I created, which allows you to deploy your DNS configuration to multiple DNS providers. 