### PR TITLE
adds create-github-action.now.sh to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Declaratively setup GitHub Labels](https://github.com/lannonbr/issue-label-manager-action)
 - [Run GitHub Actions Locally](https://github.com/nektos/act)
 - [Alternative (Python-based) for Running GitHub Actions Locally](https://github.com/systemslab/popper)
+- [GitHub Action Builder and Previewer](https://create-github-action.now.sh/)
 
 ### Collection of Actions
 


### PR DESCRIPTION
Adds https://create-github-action.now.sh to the GitHub Tools and Management list. This tool allows developers to preview what a GitHub Action will look like in the workflow UI, and generate the Dockerfile to do so.