### PR TITLE
Add link to PR Labeler action

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Auto approve pull requests](https://github.com/hmarr/auto-approve-action)
 - [Automatically add reviewers to pull request based on the configuration file](https://github.com/kentaro-m/auto-assign)
 - [Auto-commit back any changes made by previous actions](https://github.com/cds-snc/github-actions/tree/master/auto-commit)
+- [Add labels to Pull Request based on branch name patterns](https://github.com/TimonVS/pr-labeler-action)
 
 ### GitHub Pages
 


### PR DESCRIPTION
Adds link to [PR Labeler](https://github.com/TimonVS/pr-labeler-action). An action that automatically labels PRs based on branch name patterns.