### PR TITLE
Adds a docker-hub-metadata action

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Review the licenses of your node dependencies](https://github.com/cds-snc/github-actions/tree/master/node-license-checker)
 - [A GitHub Action to check your project's dependencies](https://github.com/iheanyi/licensed-action)
 - [Check if package.json dependencies have changed](https://github.com/bencooper222/check-for-node-dep-changes)
+- [Update a repository's "Full description" on Docker Hub](https://github.com/mpepping/github-actions/tree/master/docker-hub-metadata)
 
 ### Testing and Linting
 


### PR DESCRIPTION
In the **Utility** section: Adds a `docker-hub-metadata` action, to update a repository's "Full description" on Docker Hub.