### PR TITLE
Add GitHub Actions Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Review the licenses of your node dependencies](https://github.com/cds-snc/github-actions/tree/master/node-license-checker)
 - [A GitHub Action to check your project's dependencies](https://github.com/iheanyi/licensed-action)
 - [Check if package.json dependencies have changed](https://github.com/bencooper222/check-for-node-dep-changes)
+- [GitHub Actions Badges for your README](https://github.com/atrox/github-actions-badge)
 
 ### Testing and Linting
 


### PR DESCRIPTION
This allows you to add GitHub Actions Badges to your README (or other places...). A deployed instance is available [here](https://actions-badge.atrox.dev/).

Like this:
[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fatrox%2Fsync-dotenv%2Fbadge&style=flat-square)](https://actions-badge.atrox.dev/atrox/sync-dotenv/goto)

I did add this to the Utilities section, which I think fits the most but if there is a better place, I'll move it.