### PR TITLE
Adding Twitter Share GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Send a Slack message](https://github.com/apex/actions/tree/master/slack)
 - [Post a Slack message as a bot](https://github.com/pullreminders/slack-action)
 - [Update Twitter status](https://github.com/xorilog/twitter-action)
+- [Generate Tweet content to share pull request file(s) after merge](https://github.com/vsoch/twitter-share-action/tree/master/pull_request_share)
 - [Send an SMS from GitHub Actions using Nexmo](https://github.com/nexmo-community/nexmo-sms-action)
 - [Trigger emails with release notes with SendGrid](https://github.com/bitoiu/release-notify-action)
 - [Send email on failed GitHub Checks](https://github.com/cirrus-actions/email)


### PR DESCRIPTION
This action will generate text for the user to copy paste and share on Twitter, including:
 - a custom message
 - hashtags
 - "at" usernames

And specifically, it includes links to one or more files that match a pattern from the pull request just merged. I found I needed to do this because the traditional Twitter share buttons didn't work (we can't embed the widget.js from Twitter in GitHub) and then including the hashtags and "at" references in a URL to open the same interface would be truncated in the URL. The use case for this action is any GitHub user/organization that would want to encourage users to contribute content, and then be given a fun Tweet to share that.