### PR TITLE
Add paambaati/codeclimate-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Send your code coverage to codecov.io](https://github.com/atrox/codecov-action)
 - [autopep8: Automatically formats Python code to conform to the PEP 8 style guide](https://github.com/peter-evans/autopep8)
 - [xUnit Slack Reporter: Sends summary of tests from xUnit reports to a Slack channel](https://github.com/ivanklee86/xunit-slack-reporter)
+- [Publishing code coverage to CodeClimate](https://github.com/paambaati/codeclimate-action)
 
 ### Pull Requests
 


### PR DESCRIPTION
An action that helps publish code coverage to [Code Climate](https://codeclimate.com/).

Also available on the marketplace — https://github.com/marketplace/actions/code-climate-action