### PR TITLE
Added a guide for deploying Next.js project with Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Executing remote ssh commands](https://github.com/appleboy/ssh-action)
 - [Deploy to Kubernetes with kubectl](https://github.com/steebchen/kubectl)
 - [Update a Docker Hub repository description from README.md](https://github.com/peter-evans/dockerhub-description)
-- [Continuous deployment of Next.js app with Up](https://medium.com/@romanenko/simple-ci-for-next-js-projects-with-apex-up-github-actions-6f0b1b9a5400)
 
 ### External Services
 
@@ -229,6 +228,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [GitHub Actions on Android project](http://vgaidarji.me/blog/2019/01/27/github-actions)
 - [A guide to GitHub Actions using Node.js](https://datree.io/blog/git-workflow-automation-github-actions-node-js/)
 - [GitHub Actions for PHP Developers](https://stefanzweifel.io/posts/github-actions-for-php-developers/)
+- [Continuous deployment of Next.js app with Up](https://medium.com/@romanenko/simple-ci-for-next-js-projects-with-apex-up-github-actions-6f0b1b9a5400)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Executing remote ssh commands](https://github.com/appleboy/ssh-action)
 - [Deploy to Kubernetes with kubectl](https://github.com/steebchen/kubectl)
 - [Update a Docker Hub repository description from README.md](https://github.com/peter-evans/dockerhub-description)
+- [Continuous deployment of Next.js app with Up](https://medium.com/@romanenko/simple-ci-for-next-js-projects-with-apex-up-github-actions-6f0b1b9a5400)
 
 ### External Services
 


### PR DESCRIPTION
Hello! I've made a [tiny guide](https://medium.com/@romanenko/simple-ci-for-next-js-projects-with-apex-up-github-actions-6f0b1b9a5400) on how to deploy and continuously deliver [Next.js](https://nextjs.org/) project with [Apex Up](https://up.docs.apex.sh/) with short introduction to GitHub Actions. Examples and code snippets are written using recently updated Workflow YAML syntax. 

It would be awesome if we add it to Deployment section of the list!