### PR TITLE
Bump version of max/awesome-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: max/awesome-lint@1.0.0
+      - uses: max/awesome-lint@v2.0.0


### PR DESCRIPTION
I just cut a new version of max/awesome-lint that makes use of the new GitHub Actions format. This updates the lint workflow to make use of it.