### PR TITLE
Add Cloudflare cache purge action

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [Executing remote ssh commands](https://github.com/appleboy/ssh-action)
 - [Deploy to Kubernetes with kubectl](https://github.com/steebchen/kubectl)
 - [Update a Docker Hub repository description from README.md](https://github.com/peter-evans/dockerhub-description)
+- [Purge Cloudflare cache after updating a website](https://github.com/jakejarvis/cloudflare-purge-action)
 
 ### External Services
 


### PR DESCRIPTION
Made a simple action that calls the Cloudflare API to purge the cache of a website, which can be a helpful last step after deploying a new version.

Repo link: https://github.com/jakejarvis/cloudflare-purge-action
Marketplace link: https://github.com/marketplace/actions/purge-cloudflare-cache

Thanks for the great list! 😊