### PR TITLE
Link to supported (YML) format documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 ## Official Resources
 
 - [Official Site](https://github.com/features/actions)
-- [Documentation](https://developer.github.com/actions/)
+- [Beta Documentation](https://developer.github.com/actions/) (for deprecated HCL format actions)
+- [Official Documentation](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) (for YML format actions)
 - [Official Actions Collection](https://github.com/actions)
 - [GitHub Blog Announcement](https://blog.github.com/2018-10-17-action-demos/)
 


### PR DESCRIPTION
Per Github, HCL is on it's way out!

>   The documentation at https://developer.github.com/actions and support for the HCL syntax in GitHub Actions will be deprecated on September 30, 2019.
Documentation for the new limited public beta using the YAML syntax is available on https://help.github.com. See "Automating your workflow with GitHub Actions" for documentation using the YAML syntax.
