### PR TITLE
Add Chrome Lighthouse audit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 - [xUnit Slack Reporter: Sends summary of tests from xUnit reports to a Slack channel](https://github.com/ivanklee86/xunit-slack-reporter)
 - [Publishing code coverage to CodeClimate](https://github.com/paambaati/codeclimate-action)
 - [Run codeception tests](https://github.com/joelwmale/codeception-action)
+- [Audit a webpage with Google Chrome's Lighthouse tests](https://github.com/jakejarvis/lighthouse-action)
 
 ### Pull Requests
 


### PR DESCRIPTION
Whipped up a Lighthouse action inspired by your `ideas.md` list. Right now it prints scores to the workflow output and uploads the HTML/JSON results as an artifact. Still a work-in-progress, I have a few to-do's listed on the readme (like setting thresholds to make the action fail) that I'm working on now, and I'm very open to other thoughts.

Repo: https://github.com/jakejarvis/lighthouse-action
Marketplace: https://github.com/marketplace/actions/lighthouse-audit

Thanks to whoever added the idea! :)