### PR TITLE
Adding to this list official GitHub Actions forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
 ## Official Resources
 
 - [Official Site](https://github.com/features/actions)
+- [Official Community Forum Board](https://github.community/t5/GitHub-Actions/bd-p/actions)
 - [Beta Documentation](https://developer.github.com/actions/) (for deprecated HCL format actions)
 - [Official Documentation](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) (for YML format actions)
 - [Migrate Tool](https://github.com/actions/migrate) - Converts GitHub Actions main.workflow files into the new .yml syntax.


### PR DESCRIPTION
Adding to this list the official GitHub Actions forum board. This board is for the discussion of GitHub Actions, now with support for Continuous Integration and Deployment. Discussion of how they work and any questions or feedback you have about the feature are welcome here. Share your tips, tricks, and interesting actions or workflows. 