### PR TITLE
Add gobenchdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Run `localheinz/composer-normalize` to ensure your PHP project has a normalized `composer.json`](https://github.com/localheinz/composer-normalize-action)
 - [Run Go lint checks on PR event](https://github.com/ArangoGutierrez/GoLinty-Action)
 - [Node.js - Automatically run the `format` and/or `lint` script used by the package](https://github.com/MarvinJWendt/run-node-formatter)
+- [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 
 ### Pull Requests
 


### PR DESCRIPTION
gobenchdata is a tool for inspecting `go test -bench` data, and a GitHub Action for continuous benchmarking, and a [web app generator](https://gobenchdata.bobheadxi.dev/) for visualizing said benchmarks. the action runs benchmarks and uploads them to github pages!

https://github.com/bobheadxi/gobenchdata

