### PR TITLE
Add gcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [GitHub Action for JFrog CLI](https://github.com/retgits/actions/tree/master/jfrog-cli)
 - [GitHub Action for Contentful Migration CLI](https://github.com/Shy/contentful-action)
 - [GitHub Actions for Pixela (a-know/pi)](https://github.com/peaceiris/actions-pixela)
+- [GitHub Action for Google Cloud Platform (GCP)](https://github.com/exelban/gcloud)
 
 ### Frontend Tools
 


### PR DESCRIPTION
GitHub Action for Google Cloud Platform (GCP). 
[gcloud](https://github.com/exelban/gcloud)