### PR TITLE
Add git-crypt-unlock action to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Create an envfile](https://github.com/SpicyPizza/create-envfile)
 - [Update Maxmind Databases](https://github.com/meetup/maxmind-updater)
 - [Debug with SSH over tmate](https://github.com/mxschmitt/action-tmate) - Debug the Action directly by providing a SSH connection.
+- [Unlock git-crypt files](https://github.com/sliteteam/github-action-git-crypt-unlock)
 
 ### Testing and Linting
 


### PR DESCRIPTION
This action is helpful to teams using [git-crypt](https://github.com/AGWA/git-crypt) to cypher their secrets in their repo.