### PR TITLE
Adds wemake-python-styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Stylelinter - GitHub Action that runs stylelint](https://github.com/exelban/stylelint)
 - [PyCodeStyle Action - A GitHub Action that leaves a comment on your PR with pycodestyle (autopep8) feedback](https://github.com/ankitvgupta/pycodestyle-action)
+- [wemake-python-styleguide - The strictest and most opinionated python linter ever](https://github.com/wemake-services/wemake-python-styleguide)
 
 ### Pull Requests
 


### PR DESCRIPTION
Repo: https://github.com/wemake-services/wemake-python-styleguide
Docs: https://wemake-python-stylegui.de/en/latest/
Marketplace: https://github.com/marketplace/actions/wemake-python-styleguide