### PR TITLE
Add einaregilsson/build-number action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Publish GitHub Releases with Assets](https://github.com/softprops/action-gh-release)
 - [GitHub Project Automation+](https://github.com/alex-page/github-project-automation-plus) - Automate GitHub Project cards with any webhook event.
 - [Run GitHub Actions Locally with a web interface. Supports new YAML syntax](https://github.com/phishy/wflow)
+- [Generate sequential build numbers for GitHub Actions](https://github.com/einaregilsson/build-number)
 
 ### Collection of Actions
 


### PR DESCRIPTION
Add einaregilsson/build-number to the list of actions. Lets you generate sequential build numbers, useful for when you're migrating from another build system where you've labelled your artifacts with build numbers.

Documentation and examples: https://github.com/einaregilsson/build-number/blob/master/README.md