### PR TITLE
Add tag action to 'Pull Requests'

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Create a pull request for changes to your repository in the actions workspace](https://github.com/peter-evans/create-pull-request)
 - [Pull Request Lint](https://github.com/seferov/pr-lint-action)
 - [ChatOps For Pull Requests](https://github.com/machine-learning-apps/actions-chatops)
+- [Automatically Bump and Tag on Merge](https://github.com/anothrNick/github-tag-action)
 
 ### GitHub Pages
 


### PR DESCRIPTION
Add github-tag-action to `Pull Requests` category.

> A Github Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.

**Repo**
- https://github.com/anothrNick/github-tag-action

**Marketplace**
- https://github.com/marketplace/actions/github-tag-bump