### PR TITLE
Add publish-to-dev.to-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ An example: `https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%2
 - [Deploy a static site to Surge.sh](https://github.com/yavisht/deploy-via-surge.sh-github-action-template)
 - [GitHub Action for GoReleaser, a release automation tool for Go projects](https://github.com/goreleaser/goreleaser-action)
 - [FTP Deploy Action, Deploys a GitHub project to a FTP server using GitHub actions](https://github.com/SamKirkland/FTP-Deploy-Action)
+- [Publish Article to Dev.to](https://github.com/tylerauerbeck/publish-to-dev.to-action)
 
 ### External Services
 


### PR DESCRIPTION
Link: https://github.com/tylerauerbeck/publish-to-dev.to-action

This adds an action that allows you to publish markdown files to Dev.to