### PR TITLE
Add branch protection bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%20List/badge.s
 - [Restrict cursing action](https://github.com/sobolevn/restrict-cursing-action) - Moderator bot for your project, automatically removes bad language.
 - [Publish GitHub release artifacts](https://github.com/skx/github-action-publish-binaries)
 - [Jekyll Diff Action](https://github.com/David-Byrne/jekyll-diff-action) - Diffs the built Jekyll site after a change, and comments the result back to GitHub.
+- [Branch Protection Bot](https://github.com/benjefferies/branch-protection-bot) - Temporarily disable and re-enable "Include administrators" option in branch protection
 
 ### Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%20List/badge.s
 - [Restrict cursing action](https://github.com/sobolevn/restrict-cursing-action) - Moderator bot for your project, automatically removes bad language.
 - [Publish GitHub release artifacts](https://github.com/skx/github-action-publish-binaries)
 - [Jekyll Diff Action](https://github.com/David-Byrne/jekyll-diff-action) - Diffs the built Jekyll site after a change, and comments the result back to GitHub.
-- [Branch Protection Bot](https://github.com/benjefferies/branch-protection-bot) - Temporarily disable and re-enable "Include administrators" option in branch protection
+- [Branch Protection Bot](https://github.com/benjefferies/branch-protection-bot) - Temporarily disable and re-enable "Include administrators" option in branch protection.
 
 ### Testing and Linting
 


### PR DESCRIPTION
A bot tool to temporarily disable and re-enable "Include administrators" option in branch protection

Github doesn't have a way to give a Bot access to override the branch protection, specifically if you include administrators. The only possible solution is to disable the include administrators option. This increases risk of accidental pushes to master from administrators (I've done it a few times). This tool doesn't completely solve the problem of accidents happening but reduces the chances by closing the window.