### PR TITLE
Add entry to publish Google analytics using Github Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%20List/badge.s
 - [Deploy assets to GitHub pages](https://github.com/maxheld83/ghpages) - No building, just deploying.
 - [GitHub Actions for deploying to GitHub Pages with Static Site Generators](https://github.com/peaceiris/actions-gh-pages)
 - [GitHub Action for Hexo](https://github.com/heowc/action-hexo)
+- [Deploy Google Analytics stats to GitHub Pages](https://github.com/cristianpb/analytics-google)
 
 ### Notifications and Messages
 


### PR DESCRIPTION
I wrote an article about how to publish google analytics stats to github pages https://cristianpb.github.io/blog/analytics-google