### PR TITLE
add action that installs NPM dependencies and caches them

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ https://github.com/sdras/awesome-actions/workflows/Lint%20Awesome%20List/badge.s
 - [Create Milestone](https://github.com/WyriHaximus/github-action-create-milestone) - Create a new open milestone given the title and description.
 - [Close Milestone](https://github.com/WyriHaximus/github-action-close-milestone) - Close the given milestone.
 - [Action to enforce branch naming rules](https://github.com/deepakputhraya/action-branch-name)
+- [Install NPM dependencies with caching](https://github.com/bahmutov/npm-install)
 
 ### Testing and Linting
 


### PR DESCRIPTION
It is an action for projects that need to run `npm ci` or `yarn --frozen-lockfile` to install NPM dependencies and cache them

```yml
name: main
on: [push]
jobs:
  build-and-test:
    runs-on: ubuntu-latest
    name: Build and test
    steps:
      - uses: actions/checkout@v1
      - uses: bahmutov/npm-install@v1
      - run: npm t
```