### PR TITLE
Add cut release branch action to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Edit JSON File](https://github.com/deef0000dragon1/json-edit-action)
 - [Build Slate documentation](https://github.com/Decathlon/slate-builder-action)
 - [Get latest SemVer and branch name given a search string](https://github.com/jessicalostinspace/github-action-get-regex-branch)
+- [Cut Release Branch](https://github.com/jessicalostinspace/cut-release-action) - Cuts a release branch given a branch prefix and optional semantic version.
 
 ### Testing and Linting
 


### PR DESCRIPTION
Added https://github.com/jessicalostinspace/cut-release-action to utilities list which cuts a release branch given a prefix name as well as a semantic version.