### PR TITLE
Add `secret-spreader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,11 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [A vulnerability scanner for your docker images](https://github.com/phonito/phonito-scanner-action)
 - [Automatically approve and merge Dependabot updates](https://github.com/ridedott/dependabot-auto-merge-action)
 - [Run dlint security linter on your Python code](https://github.com/xen0l/dlint-check)
-- [Scan git commits for secrets with gitleaks](https://github.com/eshork/gitleaks-action)
+- [Scan git commits for 
+s with gitleaks](https://github.com/eshork/gitleaks-action)
 - [Scan for secrets in your source code](https://github.com/cds-snc/github-actions/tree/master/seekret)
 - [AWS Secrets Manager Actions](https://github.com/say8425/aws-secrets-manager-actions) - Define AWS Secrets Manager secrets to environment values.
+- [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories
 
 #### Code Coverage
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [A vulnerability scanner for your docker images](https://github.com/phonito/phonito-scanner-action)
 - [Automatically approve and merge Dependabot updates](https://github.com/ridedott/dependabot-auto-merge-action)
 - [Run dlint security linter on your Python code](https://github.com/xen0l/dlint-check)
-- [Scan git commits for 
-s with gitleaks](https://github.com/eshork/gitleaks-action)
+- [Scan git commits for secrets with gitleaks](https://github.com/eshork/gitleaks-action)
 - [Scan for secrets in your source code](https://github.com/cds-snc/github-actions/tree/master/seekret)
 - [AWS Secrets Manager Actions](https://github.com/say8425/aws-secrets-manager-actions) - Define AWS Secrets Manager secrets to environment values.
 - [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Scan git commits for secrets with gitleaks](https://github.com/eshork/gitleaks-action)
 - [Scan for secrets in your source code](https://github.com/cds-snc/github-actions/tree/master/seekret)
 - [AWS Secrets Manager Actions](https://github.com/say8425/aws-secrets-manager-actions) - Define AWS Secrets Manager secrets to environment values.
-- [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories
+- [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories.
 
 #### Code Coverage
 


### PR DESCRIPTION
[Secret Spreader](https://github.com/webfactory/secret-spreader) is not an Action per se, but a tool that can be used to maintain all your secrets in a central repository. 

Based on a config file (which is also kept under version control in that repo) the secret values will be distributed to various GH repos and set up as Actions secrets.

That way, you have a central list (think _infrastructure-as-code_) of who is using which secret. Also, it is much easier to rotate secrets if you need to use them in more than one place, as might be the case with deployment keys.
