### PR TITLE
Add xt0rted/stylelint-problem-matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Show and auto-fix linting errors for many programming languages](https://github.com/samuelmeuli/lint-action)
 - [PHP_CodeSniffer With Annotations](https://github.com/chekalsky/phpcs-action)
 - [Linter for markdown (with presets)](https://github.com/avto-dev/markdown-lint)
+- [Stylelint problem matcher to create annotations](https://github.com/xt0rted/stylelint-problem-matcher)
 
 #### Security
 


### PR DESCRIPTION
[stylelint-problem-matcher](https://github.com/xt0rted/stylelint-problem-matcher) is an action that registers a problem matcher to detect Stylelint errors in the build log and creates annotations for them.

Since this is just a problem matcher it should plug in to any existing workflow. The accompanying [report formatter is needed](https://github.com/xt0rted/stylelint-problem-matcher#using-with-sub-folders) if you're setting a custom [`working-directory`](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun) when calling your script.

Currently it has 1 option called `action` which lets you `add` or `remove` the problem matcher in the event it interferes with steps farther down in the workflow.