### PR TITLE
Add goanpeca/setup-miniconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Create an envfile](https://github.com/SpicyPizza/create-envfile)
 - [Export global environment variables for succeeding build steps](https://github.com/zweitag/github-actions)
 - [Programmatically set environment variables for use in subsequent steps](https://github.com/allenevans/set-env)
+- [Install Conda environments for Python](https://github.com/goanpeca/setup-miniconda)
 
 #### Dependencies
 


### PR DESCRIPTION
This is used to install Miniconda environments. If a new Python section header is eventually created, it should go there.