### PR TITLE
Added Autotag Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Build Slate documentation](https://github.com/Decathlon/slate-builder-action)
 - [Read Properties](https://github.com/christian-draeger/read-properties) - Read values from `.properties` files.
 - [Write Properties](https://github.com/christian-draeger/write-properties) - Write values to `.properties` files.
+- [Autotag](https://github.com/butlerlogic/action-autotag) - Automatically generate a new tag when the manifest file (i.e. `package.json`) version changes.
 
 #### Environments
 


### PR DESCRIPTION
The autotag action is a utility that automatically generates a git tag when a new version is recognized.