### PR TITLE
Added a multipublish action

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Publish a Maven package](https://github.com/samuelmeuli/action-maven-publish)
 - [Build and deploy a theme to Ghost CMS](https://github.com/TryGhost/action-deploy-theme)
 - [Deploy an Ansible role to Ansible Galaxy](https://github.com/robertdebock/galaxy-action)
-- [Publish one _or more_ JS modules to a registry](https://github.com/author/action-publish)
+- [Publish one or more JS modules to a registry](https://github.com/author/action-publish)
 
 #### Docker
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Publish a Maven package](https://github.com/samuelmeuli/action-maven-publish)
 - [Build and deploy a theme to Ghost CMS](https://github.com/TryGhost/action-deploy-theme)
 - [Deploy an Ansible role to Ansible Galaxy](https://github.com/robertdebock/galaxy-action)
+- [Publish one _or more_ JS modules to a registry](https://github.com/author/action-publish)
 
 #### Docker
 


### PR DESCRIPTION
This action scans code bases (or Github workspaces) for `package.json` files and publishes each package to the specified registry (default is npm registry).