### PR TITLE
Added Setup Cassandra Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Actions are triggered by GitHub platform events directly in a repo and run on-de
   - [Frontend Tools](#frontend-tools)
   - [Machine Learning Ops](#machine-learning-ops)
   - [Build](#build)
+  - [Database](#database)
   - [Cheat Sheet](#cheat-sheet)
 - [Tutorials](#tutorials)
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,10 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Build Go applications for multiplatform](https://github.com/izumin5210/action-go-crossbuild)
 - [Generate ~/.m2/settings.xml for Maven builds](https://github.com/whelk-io/maven-settings-xml-action)
 
+### Database
+
+- [Setup Cassandra Schema](https://github.com/fabasoad/setup-cassandra-action) - Running scripts from the provided folder on top of Cassandra cluster.
+
 ### Cheat Sheet
 
 - [GitHub Actions Branding Cheat Sheet](https://haya14busa.github.io/github-action-brandings/)


### PR DESCRIPTION
Added a link to the "Setup Cassandra action":
- [Repository](https://github.com/fabasoad/setup-cassandra-action)
- [Marketplace](https://github.com/marketplace/actions/setup-cassandra-action)

This action allows you to setup Cassandra schema.

_Note:_ I didn't find "Database" section, so I decided to create it. Please advise if it should be moved into another section. Thanks.