### PR TITLE
Added YAML/JSON/XML converter action

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Apply templates with Jinja2](https://github.com/cuchi/jinja2-action) - Use the Jinja2 template engine to generate files from templates.
 - [Has Changes](https://github.com/UnicornGlobal/has-changes-action) - Check if there are code changes from previous steps.
 - [Mind Your Language Action](https://github.com/tailaiw/mind-your-language-action) - Detect offensive comments in issues and pull requests, and warn senders.
+- [YAML/JSON/XML Converter](https://github.com/fabasoad/yaml-json-xml-converter-action) - Takes file that in YAML/JSON/XML format and produces it in output in YAML/JSON/XML format.
 
 #### Environments
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Apply templates with Jinja2](https://github.com/cuchi/jinja2-action) - Use the Jinja2 template engine to generate files from templates.
 - [Has Changes](https://github.com/UnicornGlobal/has-changes-action) - Check if there are code changes from previous steps.
 - [Mind Your Language Action](https://github.com/tailaiw/mind-your-language-action) - Detect offensive comments in issues and pull requests, and warn senders.
-- [YAML/JSON/XML Converter](https://github.com/fabasoad/yaml-json-xml-converter-action) - Converts YAML/JSON/XML file formats interchangeably.
+- [YAML/JSON/XML Converter](https://github.com/fabasoad/yaml-json-xml-converter-action) - Converts YAML/JSON/XML file formats interchangeably. 
 
 #### Environments
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Apply templates with Jinja2](https://github.com/cuchi/jinja2-action) - Use the Jinja2 template engine to generate files from templates.
 - [Has Changes](https://github.com/UnicornGlobal/has-changes-action) - Check if there are code changes from previous steps.
 - [Mind Your Language Action](https://github.com/tailaiw/mind-your-language-action) - Detect offensive comments in issues and pull requests, and warn senders.
-- [YAML/JSON/XML Converter](https://github.com/fabasoad/yaml-json-xml-converter-action) - Takes file that in YAML/JSON/XML format and produces it in output in YAML/JSON/XML format.
+- [YAML/JSON/XML Converter](https://github.com/fabasoad/yaml-json-xml-converter-action) - Converts YAML/JSON/XML file formats interchangeably.
 
 #### Environments
 


### PR DESCRIPTION
Added a link to the "YAML/JSON/XML Converter action" to _Utility_ section:
- [Repository](https://github.com/fabasoad/yaml-json-xml-converter-action)
- [Marketplace](https://github.com/marketplace/actions/yaml-json-xml-converter-action)

This action allows you to take file that in _YAML/JSON/XML_ format and produces it in output in _YAML/JSON/XML_ format.