### PR TITLE
Add 'Setup NativeScript' Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Export global environment variables for succeeding build steps](https://github.com/zweitag/github-actions)
 - [Programmatically set environment variables for use in subsequent steps](https://github.com/allenevans/set-env)
 - [Install Conda environments for Python](https://github.com/goanpeca/setup-miniconda)
-- [Setup NativeScript](https://github.com/marketplace/actions/setup-nativescript)
+- [Setup NativeScript](https://github.com/hrueger/setup-nativescript)
 
 #### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Export global environment variables for succeeding build steps](https://github.com/zweitag/github-actions)
 - [Programmatically set environment variables for use in subsequent steps](https://github.com/allenevans/set-env)
 - [Install Conda environments for Python](https://github.com/goanpeca/setup-miniconda)
+- [Setup NativeScript](https://github.com/marketplace/actions/setup-nativescript)
 
 #### Dependencies
 


### PR DESCRIPTION
Adds 'Setup NativeScript' to the list.
- [Repository](https://github.com/hrueger/setup-nativescript)
- [Marketplace](https://github.com/marketplace/actions/setup-nativescript)

This action automatically sets up the dev environment for NativeScript. It works cross-platform on Windows, MacOS and Linux.