### PR TITLE
Add has-changed-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Apply templates with Jinja2](https://github.com/cuchi/jinja2-action) - Use the Jinja2 template engine to generate files from templates.
 - [Has Changes](https://github.com/UnicornGlobal/has-changes-action) - Check if there are code changes from previous steps.
 - [Mind Your Language Action](https://github.com/tailaiw/mind-your-language-action) - Detect offensive comments in issues and pull requests, and warn senders.
+- [Has Changed Path](https://github.com/MarceloPrado/has-changed-path) - Conditionally run actions based on changed paths.
 
 #### Environments
 


### PR DESCRIPTION
This PR adds [Has Changed Path](https://github.com/MarceloPrado/has-changed-path/) action to Utility section.

The action outputs whether a path or combination of paths has changed in the previous commit.

> It solves a common issue among monorepo setups: conditional actions. Deploying a project that did not change in the previous commit could be a waste of time and resources.