### PR TITLE
Add diff-pages-action to pull request resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Pull Request Stuck Notifier](https://github.com/loomble/pull-request-stuck-notifier-action)
 - [Lint pull request name with commitlint (Awesome if you squash merge !)](https://github.com/JulienKode/pull-request-name-linter-action)
 - [Block PR merges when Checks for target branches are failing](https://github.com/cirrus-actions/branch-guard)
+- [Get generated static site screeshots updated by Pull Request](https://github.com/ssowonny/diff-pages-action)
 
 ### GitHub Pages
 


### PR DESCRIPTION
## Repository
* [diff-pages-action](https://github.com/ssowonny/diff-pages-action)
* [diff-pages-action-example](https://github.com/ssowonny/diff-pages-action-example)

## Introduction
This action takes screenshots of built static pages and find only updated screenshots. As long as it just compares the built files, the action can be integrated by any static site generators such as Hugo, middleman and jekyll.
