### PR TITLE
Add "Setup Mint" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GitHub Actions for Hugo extended](https://github.com/peaceiris/actions-hugo)
 - [Generate OG Image](https://github.com/BoyWithSilverWings/generate-og-image) - Generate customisable open graph images from Markdown files.
 - [GitHub Actions for mdBook](https://github.com/peaceiris/actions-mdbook)
+- [Setup Mint](https://github.com/fabasoad/setup-mint-action) - Setup Mint (programming language for writing single page applications).
 
 ### Machine Learning Ops
 


### PR DESCRIPTION
Added a link to the "Setup Mint" action to _Frontend Tools_ section:
- [Repository](https://github.com/fabasoad/setup-mint-action)
- [Marketplace](https://github.com/marketplace/actions/setup-mint)

This GitHub action sets up Mint - programming language for writing single page applications.