### PR TITLE
Add Setup brainfuck action

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [run-vcpkg](https://github.com/lukka/run-vcpkg) - Multi platform action to build and install C/C++ dependencies with [vcpkg](https://github.com/microsoft/vcpkg).
 - [Build Go applications for multiplatform](https://github.com/izumin5210/action-go-crossbuild)
 - [Generate ~/.m2/settings.xml for Maven builds](https://github.com/whelk-io/maven-settings-xml-action)
+- [Setup Brainfuck](https://github.com/fabasoad/brainfuck-install-action/) - Setup brainfuck interpreter.
 
 ### Database
 


### PR DESCRIPTION
Added a link to the "Setup Brainfuck" action to _Build_ section:
- [Repository](https://github.com/fabasoad/brainfuck-install-action/)
- [Marketplace](https://github.com/marketplace/actions/brainfuck-install)

This GitHub action installs one of many brainfuck interpreters called [brainfucky](https://pypi.org/project/brainfucky/).