### PR TITLE
Add metcalfc/changelog-generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Rollback a GitHub Release](https://github.com/author/action-rollback)
 - [Lock Closed Issues and Pull Requests after a Period of Inactivity](https://github.com/dessant/lock-threads)
 - [Get Commit Difference Count Between Two Branches](https://github.com/jessicalostinspace/commit-difference-action)
+- [Generate Release Notes Based on Git References](https://github.com/metcalfc/changelog-generator)
 
 ### Collection of Actions
 


### PR DESCRIPTION
This action generates a markdown formatted list of commits between two git references. The other changelog generators in this list use milestones. This one can use tags, branches, SHAs. By default it uses the action triggering SHA and the latest release tag. Making for easy release automation.