### PR TITLE
chore: Add ECR Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Update a repository's "Full description" on Docker Hub](https://github.com/mpepping/github-actions/tree/master/docker-hub-metadata)
 - [Build and publish docker images to any registry using Kaniko](https://github.com/outillage/kaniko-action)
 - [Monitor and limit your docker image size](https://github.com/wemake-services/docker-image-size-limit)
+- [Publish Docker Images to the Amazon Elastic Container Registry (ECR)](https://github.com/appleboy/docker-ecr-action)
 
 #### Kubernetes
 


### PR DESCRIPTION
Publish Docker Images to the Amazon Elastic Container Registry (ECR)

See https://github.com/appleboy/docker-ecr-action