### PR TITLE
Add BuildPulse action for detecting flaky tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run Cypress E2E tests](https://github.com/cypress-io/github-action)
 - [Test Ansible roles with Molecule](https://github.com/robertdebock/molecule-action)
 - [Run performance testing with artillery.io](https://github.com/kenju/github-actions-artillery)
+- [Detect Flaky Tests with BuildPulse](https://github.com/Workshop64/buildpulse-action)
 
 #### Linting
 


### PR DESCRIPTION
This pull request adds a link to the "BuildPulse" action in the Testing section:

- [Repository](https://github.com/Workshop64/buildpulse-action)
- [Marketplace](https://github.com/marketplace/actions/buildpulse)

This action sends tests results to [BuildPulse](https://github.com/marketplace/buildpulse/) to identify flaky tests.
