### PR TITLE
Adding Setup COBOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,9 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Build Go applications for multiplatform](https://github.com/izumin5210/action-go-crossbuild)
 - [Generate ~/.m2/settings.xml for Maven builds](https://github.com/whelk-io/maven-settings-xml-action)
 - [Run Pascal Script](https://github.com/fabasoad/pascal-action)
-- [Setup Brainfuck](https://github.com/fabasoad/brainfuck-install-action/) - Setup brainfuck interpreter.
+- [Setup Brainfuck](https://github.com/fabasoad/setup-brainfuck-action) - Setup brainfuck interpreter.
 - [Publish Go Binaries to GitHub Release Assets](https://github.com/wangyoucao577/go-release-action)
+- [Setup COBOL](https://github.com/fabasoad/setup-cobol-action)
 
 ### Database
 


### PR DESCRIPTION
Added a link to the "Setup COBOL" action to _Build_ section:
- [Repository](https://github.com/fabasoad/setup-cobol-action)
- [Marketplace](https://github.com/marketplace/actions/setup-cobol)

his action sets up a COBOL programming language. Currently supports Linux Ubuntu only.
> Also, I have changed the link for "Setup Brainfuck" action to the actual one. Please let me know in case you want me to create a separate PR for this change.