### PR TITLE
Remove actions/github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Tool actions for your workflow.
 
 <!--lint ignore awesome-spell-check-->
 
-- [actions/github](https://github.com/actions/github) - Wraps actions-toolkit into an Action for common GitHub automations.
 - [actions/checkout](https://github.com/actions/checkout) - Setup your repository on your workflow.
 - [actions/upload-artifact](https://github.com/actions/upload-artifact) - Upload artifacts from your workflow.
 - [actions/download-artifact](https://github.com/actions/download-artifact) - Download artifacts from your build.


### PR DESCRIPTION
actions/github is deprecated as of https://github.com/actions/github/commit/8436f278d078afda032acdb40c7dcd6414fa186a