### PR TITLE
Adding check my bundlephobia action

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
-- [Check my bundlephobia Action](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website. Let's you also reject PR on threshold surpassed.
+- [Check bundlephobia](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website and rejects PR on threshold surpassed.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
-- [Check my bundlephobia Action](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website. Let's you also reject PR on threshold surpassed 
+- [Check my bundlephobia Action](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website. Let's you also reject PR on threshold surpassed.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
+- [Check my bundlephobia Action](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website. Let's you also reject PR on threshold surpassed 
 
 ### Pull Requests
 


### PR DESCRIPTION
This PR add check my bundlephobia github action. This action will post you a table with the size of the packages that have been added or modified on a PR letting you even reject the pr if a threshold is surpassed.
<img width="783" alt="Screenshot 2020-04-27 at 14 47 39" src="https://user-images.githubusercontent.com/5639972/80373894-11016f00-8896-11ea-8b20-ca09a7aae72f.png">
