### PR TITLE
Add GHACU to "GitHub Tools and Management" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Generate Release Notes Based on Git References](https://github.com/metcalfc/changelog-generator)
 - [Enforce Policies on GitHub Repositories and Commits](https://github.com/talos-systems/conform)
 - [Auto Label Issue Based on Issue Description](https://github.com/Renato66/auto-label)
-- [Update configured GitHub Actions to the latest versions](https://github.com/fabasoad/ghacu)
+- [Update Configured GitHub Actions to the Latest Versions](https://github.com/fabasoad/ghacu)
 
 ### Collection of Actions
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Get Commit Difference Count Between Two Branches](https://github.com/jessicalostinspace/commit-difference-action)
 - [Generate Release Notes Based on Git References](https://github.com/metcalfc/changelog-generator)
 - [Enforce Policies on GitHub Repositories and Commits](https://github.com/talos-systems/conform)
+- [Update configured GitHub Actions to the latest versions](https://github.com/fabasoad/ghacu)
 
 ### Collection of Actions
 


### PR DESCRIPTION
_GitHub Actions Check Updates (GHACU)_ is a tool that helps you to keep versions of configured GitHub Actions up-to-date. Here is how it looks like in action:
```console
PS C:\Projects\linguist-action> ghacu
> Dockerfile Lint (.github\workflows\dockerfile-lint.yml)
actions/checkout               v2.0.0  »  v2.1.0
burdzwastaken/hadolint-action  master  »   1.1.0

> Shell Lint (.github\workflows\shell-lint.yml)
actions/checkout                v1  »  v2.1.0
bewuethr/shellcheck-action  v2.0.1  »  v2.0.2

> YAML Lint (.github\workflows\yaml-lint.yml)
ibiqlik/action-yamllint  v0.0.2  »  v1.0.0

Run ghacu -u to upgrade actions.
```
More details [here](https://dev.to/fabasoad/introducing-github-actions-check-updates-42ad).