### PR TITLE
Add „ Annotate a GitHub Pull Request based on a Checkstyle XML-report“

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Block PR merges when Checks for target branches are failing](https://github.com/cirrus-actions/branch-guard)
 - [Get generated static site screeshots updated by Pull Request](https://github.com/ssowonny/diff-pages-action)
 - [Add Labels Depending if the Pull Request Still in Progress](https://github.com/AlbertHernandez/working-label-action)
+- [Annotate a Github Pull Request based on a Checkstyle XML-report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 
 ### GitHub Pages
 


### PR DESCRIPTION
> Turns checkstyle based XML-Reports into GitHub Pull Request Annotations via the Checks API. This script is meant for use within your GitHub Action.
That means you no longer search thru your GitHub Action logfiles. No need to interpret messages which are formatted differently with every tool. Instead you can focus on your Pull Request, and you don't need to leave the Pull Request area.

![Context Example](https://github.com/mheap/phpunit-github-actions-printer/blob/master/phpunit-printer-context.png?raw=true)

[Project Readme](https://github.com/staabm/annotate-pull-request-from-checkstyle/blob/master/README.md)