### PR TITLE
Fix: Name and reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [JavaScript-based linter for \*.workflow files](https://github.com/OmarTawfik/github-actions-js)
 - [Lint terraform files using tflint, with reviewdog output on the PR](https://github.com/reviewdog/action-tflint)
 - [autopep8: Automatically formats Python code to conform to the PEP 8 style guide](https://github.com/peter-evans/autopep8)
-- [Run `localheinz/composer-normalize` to ensure your PHP project has a normalized `composer.json`](https://github.com/localheinz/composer-normalize-action)
+- [Run `ergebnis/composer-normalize` to ensure your PHP project has a normalized `composer.json`](https://github.com/ergebnis/composer-normalize-action)
 - [Run Go lint checks on PR event](https://github.com/ArangoGutierrez/GoLinty-Action)
 - [Node.js - Automatically run the `format` and/or `lint` script used by the package](https://github.com/MarvinJWendt/run-node-formatter)
 - [Stylelinter - GitHub Action that runs stylelint](https://github.com/exelban/stylelint)


### PR DESCRIPTION
This PR

* [x] fixes the name of an action and the reference to it

💁‍♂️ I have moved `localheinz/composer-normalize-action` from my personal account @localheinz to the @ergebnis organization, and consequently renamed everything. For reference, also see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis//