### PR TITLE
Add Highlight New NPM Dependencies action

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 #### Dependencies
 
 - [Install NPM dependencies with caching](https://github.com/bahmutov/npm-install)
-- [Highlight New NPM Dependencies](https://github.com/hiwelo/new-dependencies-action) - Comment pull requests with information about new NPM dependencies added.
+- [Highlight New NPM Dependencies](https://github.com/hiwelo/new-dependencies-action) - Comments on pull requests newly added NPM dependencies information.
 
 #### Semantic Versioning
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 #### Dependencies
 
 - [Install NPM dependencies with caching](https://github.com/bahmutov/npm-install)
+- [Highlight New NPM Dependencies](https://github.com/hiwelo/new-dependencies-action) - Comment pull requests with information about new NPM dependencies added.
 
 #### Semantic Versioning
 


### PR DESCRIPTION
This commit introduces the [Highlight New NPM Dependencies](https://github.com/hiwelo/new-dependencies-action) to this list of GitHub actions, in the `Dependencies` section.

This action aims to comment pull requests introducing new (dev-)dependencies in a project, with a set of basic information about the new dependencies.
It also works with monorepos.

* [Action in the marketplace](https://github.com/marketplace/actions/highlight-new-npm-dependencies)
* [Repository of this action](https://github.com/hiwelo/new-dependencies-action)

I hope it's compliant with the contribution guidelines (at least, I tried to), please let me know if there is anything to change 😸 