### PR TITLE
GitHub Status monitoring Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
+- [GitHub Status monitoring Action](https://github.com/crazy-max/ghaction-github-status)
 
 ### Pull Requests
 


### PR DESCRIPTION
A GitHub Action to check GitHub Status in your workflow.

Can be informative:

![image](https://user-images.githubusercontent.com/1951866/82743261-2a002180-9d69-11ea-9fe8-d3b2841d41f6.png)

Or can trigger an error if GitHub services are down. This can be useful if you have an action that publishes to GitHub Pages but the service is down.

![image](https://user-images.githubusercontent.com/1951866/82743270-4d2ad100-9d69-11ea-97c9-012c06604b4c.png)
