### PR TITLE
Add external-repo-sync-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Enforce Policies on GitHub Repositories and Commits](https://github.com/talos-systems/conform)
 - [Auto Label Issue Based on Issue Description](https://github.com/Renato66/auto-label)
 - [Update Configured GitHub Actions to the Latest Versions](https://github.com/fabasoad/ghacu)
+- [Sync Defined Files/Binaries to Wiki or External Repositories](https://github.com/kai-tub/external-repo-sync-action)
 
 ### Collection of Actions
 


### PR DESCRIPTION
https://github.com/kai-tub/external-repo-sync-action

Provides a GitHub action to push files/binaries to external repositories.

Per default, the action uses the wiki of the current repo, but you can specify other repos as well.

The action is a rsync and git wrapper with some presets to allow easy inclusion/exclusion of files.