### PR TITLE
Add link how to setup self-hosted runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Zero Downtime Laravel Deployments with GitHub Actions](https://atymic.dev/blog/github-actions-laravel-ci-cd/)
 - [Building Custom GitHub Actions Pluralsight Course](https://www.pluralsight.com/courses/building-custom-github-actions/)
 - [Continuously Deploying Django to DigitalOcean with Docker and GitHub Actions](https://testdriven.io/blog/deploying-django-to-digitalocean-with-docker-and-github-actions/)
+- [Setup Auto-scaled self-hosted GitHub Actions Runners on AWS Spot-instances](https://040code.github.io/2020/05/25/scaling-selfhosted-action-runners)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information
 


### PR DESCRIPTION
Add link to tutorial how to setup auto-scaled self-hosted github actions runners.
https://040code.github.io/2020/05/25/scaling-selfhosted-action-runners