### PR TITLE
Add full-scale GitHub wiki page action

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Enforce Policies on GitHub Repositories and Commits](https://github.com/talos-systems/conform)
 - [Auto Label Issue Based on Issue Description](https://github.com/Renato66/auto-label)
 - [Update Configured GitHub Actions to the Latest Versions](https://github.com/fabasoad/ghacu)
+- [Create/Update/Delete your GitHub wiki pages based on any file](https://github.com/Andrew-Chen-Wang/github-wiki-action)
 
 ### Collection of Actions
 


### PR DESCRIPTION
My GitHub wiki page is based on one that is already listed https://github.com/Decathlon/wiki-page-creator-action but the mine is different in that it allows for any type of file, not just Markdown, usage of `secrets.GITHUB_TOKEN`, exclude files and directory, and allows for deletion of pages if the file is deleted, unlike the other repository in which if the files are deleted, then the wiki DOES NOT reflect that (as in the wiki's page is still there).

Repo: https://github.com/Andrew-Chen-Wang/github-wiki-action

Marketplace: https://github.com/marketplace/actions/github-wiki-action