### PR TITLE
Add "Publish VS Code Extension" Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Netlify Deploy GitHub Action for each commit](https://github.com/nwtgck/actions-netlify)
 - [Run Ansible Playbooks](https://github.com/arillso/action.playbook)
 - [Publish a Python Distribution Package to Anaconda Cloud](https://github.com/fcakyon/conda-publish-action)
+- [Deploy VS Code Extension to Visual Studio Marketplace or the Open VSX Registry](https://github.com/HaaLeo/publish-vscode-extension)
 
 #### Docker
 


### PR DESCRIPTION
Added [Publish VS Code Extension](https://github.com/HaaLeo/publish-vscode-extension) to the deployment list.
This action allows to publish VS Code extensions to the Open VSX Registry as well as to the Visual Studio Marketplace