### PR TITLE
Add Gatsby AWS S3 Deployment Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Generate OG Image](https://github.com/BoyWithSilverWings/generate-og-image) - Generate customisable open graph images from Markdown files.
 - [GitHub Actions for mdBook](https://github.com/peaceiris/actions-mdbook)
 - [Setup Mint](https://github.com/fabasoad/setup-mint-action) - Setup Mint (programming language for writing single page applications).
+- [Gatsby AWS S3 Deployment](https://github.com/jonelantha/gatsby-s3-action) - Deploy Gatsby to S3 (supports CloudFront).
 
 ### Machine Learning Ops
 


### PR DESCRIPTION
Deploy a Gatsby site to AWS S3 (supports CloudFront)
(added to Frontend Tools section)

[Marketplace](https://github.com/marketplace/actions/deploy-gatsby-to-aws-s3)
[Repo](https://github.com/jonelantha/gatsby-s3-action)