### PR TITLE
Remove actionspanel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Create a GitHub wiki page based on the provided markdown file](https://github.com/Decathlon/wiki-page-creator-action)
 - [Label your Pull Requests auto-magically (using committed files)](https://github.com/Decathlon/pull-request-labeler-action)
 - [Add Label to your Pull Requests based on the author team name](https://github.com/JulienKode/team-labeler-action)
-- [Manually trigger your GitHub Actions from a UI](https://www.actionspanel.app)
 - [Get a list of file changes with PR/Push](https://github.com/trilom/file-changes-action)
 - [Use private actions in any workflow](https://github.com/InVisionApp/private-action-loader)
 - [Label Your Issues Using the Issue's Contents](https://github.com/damccorm/tag-ur-it)


### PR DESCRIPTION
We're shutting down this service since GitHub supports manual triggers on their own now:
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/