### PR TITLE
Add LibreSelery

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Prow GitHub Actions](https://github.com/jpmcb/prow-github-actions) - Automation of policy enforcement, chat-ops, and automatic PR merging.
 - [Check GitHub Status in your Workflow](https://github.com/crazy-max/ghaction-github-status)
 - [Manage Labels on GitHub (create/rename/update/delete) as Code](https://github.com/crazy-max/ghaction-github-labeler)
+- [Continuous Funding distribution to your project contributors and dependencies](https://github.com/protontypes/libreselery)
 
 ### Collection of Actions
 


### PR DESCRIPTION
We just made our first release. 
Find more information in our blog post on LibreSelery:
https://protontypes.eu/blog/2020/09/02/launch-of-protontypes/

As an alternative, we could also add the Action template. 
https://github.com/protontypes/seleryaction

