### PR TITLE
add s3cmd bucket sync action and cf invalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 
 - [Sync/upload a directory to an AWS S3 bucket](https://github.com/jakejarvis/s3-sync-action)
 - [Deploy Lambda code to an existing function](https://github.com/appleboy/lambda-action)
+- [Sync/Invalidate files and send it to AWS S3 using s3cmd](https://github.com/ThiagoAnunciacao/s3cmd-sync-action)
 
 #### Terraform
 


### PR DESCRIPTION
This action uses the s3cmd to sync a directory (either from your repository or generated during your workflow) with a remote AWS S3 bucket, as this action is using s3cmd, we could do awesome things like, cloudfront invalidate for the files that really need to be invalidated and the possibility to set file headers like cache-control.

Repo: https://github.com/ThiagoAnunciacao/s3cmd-sync-action
Marketplace: https://github.com/marketplace/actions/s3cmd-sync-action

Thanks you!