### PR TITLE
Add "Getting the Gist of GitHub Actions" to tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Continuously Deploying Django to DigitalOcean with Docker and GitHub Actions](https://testdriven.io/blog/deploying-django-to-digitalocean-with-docker-and-github-actions/)
 - [Deploying Self-Hosted GitHub Actions Runners with Docker](https://testdriven.io/blog/github-actions-docker/) - Deploy self-hosted GitHub Actions runners with Docker and Docker Swarm to DigitalOcean.
 - [Setup Auto-scaled self-hosted GitHub Actions Runners on AWS Spot-instances](https://040code.github.io/2020/05/25/scaling-selfhosted-action-runners)
+- [Getting the Gist of GitHub Actions](https://gist.github.com/br3ndonland/f9c753eb27381f97336aa21b8d932be6)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information.
 


### PR DESCRIPTION
I'd like to add "[Getting the Gist of GitHub Actions](https://gist.github.com/br3ndonland/f9c753eb27381f97336aa21b8d932be6)" to the tutorials section. It's a Gist with a GitHub Actions tutorial, example workflows, and pro tips.

The tutorial demonstrates how to:

- Use context and expression syntax
- Use secrets to keep workflows secure
- Run shell and Python script blocks
- Run external shell and Python scripts
- Set up build matrices (the example spins up 27 virtual machines in parallel)

The Gist also contains information on current limitations of GitHub Actions, and how to work around those limitations.

I will keep the Gist updated as new GitHub Actions features are released.
