### PR TITLE
Add an action for AWS CodeDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Publish a Python Distribution Package to Anaconda Cloud](https://github.com/fcakyon/conda-publish-action)
 - [Deploy VS Code Extension to Visual Studio Marketplace or the Open VSX Registry](https://github.com/HaaLeo/publish-vscode-extension)
 - [Deploy a YouTube Video to Anchor.fm Podcast](https://github.com/Schrodinger-Hat/youtube-to-anchorfm)
+- [Deploy with AWS CodeDeploy](https://github.com/webfactory/create-aws-codedeploy-deployment)
 
 #### Docker
 


### PR DESCRIPTION
This adds https://github.com/webfactory/create-aws-codedeploy-deployment to the list – an action to create AWS CodeDeploy deployments.

For more details on CodeDeploy, see https://aws.amazon.com/de/codedeploy/.