### PR TITLE
Add Copybara Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Check GitHub Status in your Workflow](https://github.com/crazy-max/ghaction-github-status)
 - [Manage Labels on GitHub (create/rename/update/delete) as Code](https://github.com/crazy-max/ghaction-github-labeler)
 - [Herald Rules for GitHub: Add Subscribers, Assignees, Labels, and More to Your PR](https://github.com/gagoar/use-herald-action)
+- [Copybara Action](https://github.com/olivr/copybara-action) - Move and transform code between repositories (ideal to maintain several repos from one monorepo)
 
 ### Collection of Actions
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Check GitHub Status in your Workflow](https://github.com/crazy-max/ghaction-github-status)
 - [Manage Labels on GitHub (create/rename/update/delete) as Code](https://github.com/crazy-max/ghaction-github-labeler)
 - [Herald Rules for GitHub: Add Subscribers, Assignees, Labels, and More to Your PR](https://github.com/gagoar/use-herald-action)
-- [Copybara Action](https://github.com/olivr/copybara-action) - Move and transform code between repositories (ideal to maintain several repos from one monorepo)
+- [Copybara Action](https://github.com/olivr/copybara-action) - Move and transform code between repositories (ideal to maintain several repos from one monorepo).
 
 ### Collection of Actions
 


### PR DESCRIPTION
Added [Copybara Action](https://github.com/olivr/copybara-action), an action to move and transform code between repositories (ideal to maintain several repos from one monorepo)