### PR TITLE
Add "Deploy Static Site to AWS" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 
 - [Sync/upload a directory to an AWS S3 bucket](https://github.com/jakejarvis/s3-sync-action)
 - [Deploy Lambda code to an existing function](https://github.com/appleboy/lambda-action)
+- [Deploy Static Site to AWS](https://github.com/onramper/action-deploy-aws-static-site)
 
 #### Terraform
 


### PR DESCRIPTION
Added [due to a suggestion on reddit](https://www.reddit.com/r/aws/comments/ja1k9g/i_built_a_github_action_that_deploys_static_sites/g8pex80?utm_source=share&utm_medium=web2x&context=3). This action handles everything needed to deploy a static site to AWS, including certificates, DNS records, cache invalidation...

Action: https://github.com/onramper/action-deploy-aws-static-site