### PR TITLE
Add Image Actions to Front-end Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GitHub Actions for mdBook](https://github.com/peaceiris/actions-mdbook)
 - [Setup Mint](https://github.com/fabasoad/setup-mint-action) - Setup Mint (programming language for writing single page applications).
 - [Gatsby AWS S3 Deployment](https://github.com/jonelantha/gatsby-s3-action) - Deploy Gatsby to S3 (supports CloudFront).
+- [Image Actions](https://github.com/calibreapp/image-actions) - Automatically compress JPEGs, PNGs and WebPs in Pull Requests.
 
 ### Machine Learning Ops
 


### PR DESCRIPTION
## This PR

* adds [Image Actions](https://github.com/calibreapp/image-actions), an action that automatically compresses images in your PRs, to the Front-end Tooling section

👋  @sdras. I added this to the Front-end Tooling section as the best fit, although maybe there's enough here (a handful of WPT and Lighthouse actions) to create a dedicated Web Performance section—up to you! happy to make edits if you think it's fitting.