### PR TITLE
Add ReDoc CLI GitHub Action to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GitHub Action Locks](https://github.com/abatilo/github-action-locks/blob/master/README.md) - Guarantee atomic execution of your GitHub Action workflows.
 - [Paths Filter](https://github.com/dorny/paths-filter) - Conditionally run actions based on files modified by PR, feature branch or pushed commits.
 - [Minisauras](https://github.com/TeamTigers/minisauras) -  Pulls all the JavaScript and CSS files from your base branch, minify them and creates a pull-request with a new branch.
+- [ReDoc CLI GitHub Action](https://github.com/seeebiii/redoc-cli-github-action) - Use redoc-cli in your GitHub Action to generate OpenAPI documentation.
 
 #### Environments
 


### PR DESCRIPTION
This action lets you use the [redoc-cli](https://www.npmjs.com/package/redoc-cli) to generate a HTML version of your OpenAPI documents.