### PR TITLE
Add "Setup LOLCODE" GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Setup Brainfuck](https://github.com/fabasoad/setup-brainfuck-action) - Setup brainfuck interpreter.
 - [Publish Go Binaries to GitHub Release Assets](https://github.com/wangyoucao577/go-release-action)
 - [Setup COBOL](https://github.com/fabasoad/setup-cobol-action)
+- [Setup LOLCODE](https://github.com/fabasoad/setup-lolcode-action)
 
 ### Database
 


### PR DESCRIPTION
Added a link to the "Setup LOLCODE" action to _Build_ section:
- [Repository](https://github.com/fabasoad/setup-lolcode-action)
- [Marketplace](https://github.com/marketplace/actions/setup-lolcode)

This GitHub action sets up LOLCODE - programming language.