### PR TITLE
Add "Setup Shakespeare" GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Setup Brainfuck](https://github.com/fabasoad/setup-brainfuck-action) - Setup brainfuck interpreter.
 - [Publish Go Binaries to GitHub Release Assets](https://github.com/wangyoucao577/go-release-action)
 - [Setup COBOL](https://github.com/fabasoad/setup-cobol-action)
+- [Setup Shakespeare](https://github.com/fabasoad/setup-shakespeare-action)
 
 ### Database
 


### PR DESCRIPTION
Added a link to the "Setup Shakespeare" action to _Build_ section:
- [Repository](https://github.com/fabasoad/setup-shakespeare-action)
- [Marketplace](https://github.com/marketplace/actions/setup-shakespeare)

This GitHub action sets up Shakespeare - programming language.