### PR TITLE
Add "Setup Wren" GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Setup Brainfuck](https://github.com/fabasoad/setup-brainfuck-action) - Setup brainfuck interpreter.
 - [Publish Go Binaries to GitHub Release Assets](https://github.com/wangyoucao577/go-release-action)
 - [Setup COBOL](https://github.com/fabasoad/setup-cobol-action)
+- [Setup Wren](https://github.com/fabasoad/setup-wren-action)
 
 ### Database
 


### PR DESCRIPTION
Added a link to the "Setup Wren" action to _Build_ section:
- [Repository](https://github.com/fabasoad/setup-wren-action)
- [Marketplace](https://github.com/marketplace/actions/setup-wren-cli)

This GitHub action sets up Wren - programming language.