### PR TITLE
Add "ICQ Notify" GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Send an Embed Message to Discord](https://github.com/sarisia/actions-status-discord)
 - [Keep Your PRs in Sync With Teamwork Tasks](https://github.com/Teamwork/github-sync)
 - [Send Microsoft Teams Notification](https://github.com/opsless/ms-teams-github-actions)
+- [Send ICQ Message](https://github.com/fabasoad/icq-notify-action)
 
 ### Deployment
 


### PR DESCRIPTION
Added a link to the "Send ICQ Message" action to _Notifications and Messages_ section:
- [Repository](https://github.com/fabasoad/icq-notify-action)
- [Marketplace](https://github.com/marketplace/actions/icq-notify)

This GitHub action sends a message to ICQ personal chat or group chat.