### PR TITLE
Added Issue Watcher Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Herald Rules for GitHub: Add Subscribers, Assignees, Labels, and More to Your PR](https://github.com/gagoar/use-herald-action)
 - [GitHub Codeowners Validator](https://github.com/mszostok/codeowners-validator) - Ensures the correctness of your GitHub CODEOWNERS file. It supports public and private GitHub repositories and also GitHub Enterprise installations.
 - [Copybara Action](https://github.com/olivr/copybara-action) - Move and transform code between repositories (ideal to maintain several repos from one monorepo).
-
+- [Issue Watcher](https://github.com/anushkrishnav/Issue-Watcher) - Monitors and Restricts the number of Issues open by a person at a time to the given limit. Prements Issue spam.
 ### Collection of Actions
 
 - [Use HashiCorp's Terraform](https://github.com/hashicorp/setup-terraform)


### PR DESCRIPTION
Added my Github action that monitors the number of issues that can be left open at a time say 2 open issues or 3 this limit can be fixed by the maintainer. Helps to stop spamming for issues during opensource events. Used here https://github.com/anushkrishnav/Issue-Watcher