### PR TITLE
Add Cobertura action

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Send your code coverage to codecov.io](https://github.com/codecov/codecov-action)
 - [Publishing code coverage to CodeClimate](https://github.com/paambaati/codeclimate-action)
 - [Update repository go report card](https://github.com/creekorful/goreportcard-action)
+- [Post your Cobertura report as a PR comment](https://github.com/5monkeys/cobertura-action)
 
 ### Dynamic Analysis
 


### PR DESCRIPTION
GitHub Action which parses an [XML Cobertura report](http://cobertura.github.io/cobertura/) and displays the metrics in a GitHub Pull Request.

# What it looks like

![image](https://user-images.githubusercontent.com/74944/132222155-5cf4d135-e4bd-41f0-a9a6-e176aa4af4b9.png)
