### PR TITLE
Add Setup Vim/Neovim Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GitHub Action Locks](https://github.com/abatilo/github-action-locks/blob/master/README.md) - Guarantee atomic execution of your GitHub Action workflows.
 - [Paths Filter](https://github.com/dorny/paths-filter) - Conditionally run actions based on files modified by PR, feature branch or pushed commits.
 - [Minisauras](https://github.com/TeamTigers/minisauras) -  Pulls all the JavaScript and CSS files from your base branch, minify them and creates a pull-request with a new branch.
+- [Setup Vim/Neovim](https://github.com/rhysd/action-setup-vim) - Install Vim/Neovim for testing editor plugins.
 
 #### Environments
 


### PR DESCRIPTION
[action-setup-vim](https://github.com/rhysd/action-setup-vim) is an action to setup Vim/Neovim for testing editor plugins. This tool is useful to install various versions of the editors; stable, nightly, specific version for every platform (Linux, Windows, macOS) which GitHub Actions supports.

This action is already used by many uses. Here is the search result on GitHub: https://github.com/search?l=YAML&q=%22rhysd%2Faction-setup-vim%22&type=Code