### PR TITLE
Adding k3d-action to Kubernetes Actions ⚡ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Deploy to Kubernetes with kubectl](https://github.com/steebchen/kubectl)
 - [Get Kubeconfig File From Google Kubernetes Engine (GKE)](https://github.com/machine-learning-apps/gke-kubeconfig)
 - [Kustomize Kubernetes Config YAMLs](https://github.com/karancode/kustomize-github-action)
+- [Create a K3s Clusters for Testing Using K3d](https://github.com/AbsaOSS/k3d-action)
 - [Create a Kubernetes Cluster for Testing Using Krucible](https://github.com/Krucible/krucible-github-action)
 
 #### AWS


### PR DESCRIPTION
A GitHub Action to run lightweight ephemeral Kubernetes clusters during workflow. Fundamental advantage
of this action is a full customization of embedded k3s clusters. The action is useful for multi-cluster testing.

Signed-off-by: kuritka <kuritka@gmail.com>