### PR TITLE
add Deploy to Vercel in Deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Publish a Python Distribution Package to Anaconda Cloud](https://github.com/fcakyon/conda-publish-action)
 - [Deploy VS Code Extension to Visual Studio Marketplace or the Open VSX Registry](https://github.com/HaaLeo/publish-vscode-extension)
 - [Deploy a YouTube Video to Anchor.fm Podcast](https://github.com/Schrodinger-Hat/youtube-to-anchorfm)
+- [Deploy to Vercel](https://github.com/amondnet/vercel-action) - Deploying via GitHub action allows more granular control than through the Vercel-GitHub integration.
 
 #### Docker
 


### PR DESCRIPTION
Linking to this action: https://github.com/amondnet/vercel-action

There is a direct Vercel-GitHub integration, but deploying via the action allows more granular control, and can run tests against the deployment, etc.