### PR TITLE
Add the stale action to process your issues and PRs that didn't have recent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Automate management for issues, pull requests, and releases.
 - [actions/upload-release-asset](https://github.com/actions/upload-release-asset) - An Action to upload a release asset via the GitHub Release API.
 - [actions/first-interaction](https://github.com/actions/first-interaction) - An action for filtering pull requests and issues from first-time contributors.
 - [actions/stale](https://github.com/actions/stale) - Marks issues and pull requests that have not had recent interaction.
+- [Sonia-corporation/stale](https://github.com/Sonia-corporation/stale) - Process your issues and pull requests that didn't have recent updates.
 - [actions/labeler](https://github.com/actions/labeler) - An action for automatically labelling pull requests.
 - [actions/delete-package-versions](https://github.com/actions/delete-package-versions) - Delete versions of a package from GitHub Packages.
 


### PR DESCRIPTION
Repository: https://github.com/Sonia-corporation/stale
Docs: https://sonia-corporation.github.io/stale/

Note that I was an active contributor of https://github.com/actions/stale, which is already listed, and this action is mostly the same, but with numerous more features, from scratch implementation and active maintenance.
To avoid duplication, maybe this PR could replace this action, instead of adding a new entry.