### PR TITLE
Add link to Garm self-hosted runner manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Deploying Self-Hosted GitHub Actions Runners with Docker](https://testdriven.io/blog/github-actions-docker/) - Deploy self-hosted GitHub Actions runners with Docker and Docker Swarm to DigitalOcean.
 - [Setup Auto-scaled self-hosted GitHub Actions Runners on AWS Spot-instances](https://040code.github.io/2020/05/25/scaling-selfhosted-action-runners)
 - [Getting the Gist of GitHub Actions](https://gist.github.com/br3ndonland/f9c753eb27381f97336aa21b8d932be6)
+- [Define Pools of self-hosted Action Runners on LXD, OpenStack or Other Clouds Using Garm](https://github.com/cloudbase/garm/)
 
 > Please don't hesitate to make a PR if you have more resources to share. Check out [contributing.md](contributing.md) for more information.
 


### PR DESCRIPTION
This change adds a link to the GitHub Self-Hosted Runner Manager (garm). Garm is a simple, extensible pool manager for GitHub self-hosted runners. It works with LXD (virtual machines) or any other cloud for which an external provider can be written  examples currently exist for Azure and OpenStack).

The project can be found here: https://github.com/cloudbase/garm/
A demo video can be found here: https://www.youtube.com/watch?v=p3Z1sAW6E1s