### PR TITLE
Add cicirello/jacoco-badge-generator GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Send your code coverage to codecov.io](https://github.com/codecov/codecov-action)
 - [Publishing code coverage to CodeClimate](https://github.com/paambaati/codeclimate-action)
 - [Update repository go report card](https://github.com/creekorful/goreportcard-action)
+- [Pull Request Coverage Checks and Coverage Badges from JaCoCo Coverage Reports](https://github.com/cicirello/jacoco-badge-generator)
 
 ### Dynamic Analysis
 


### PR DESCRIPTION
https://github.com/cicirello/jacoco-badge-generator

This GitHub Action parses JaCoCo coverage reports, generates coverage badges as SVG images, and can be used for pull request coverage checks (e.g., to verify minimum coverage, and to check if coverage decreased since last run).