### PR TITLE
docs: add top-issues-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run your job on another architecture: arm32, aarch64 and others](https://github.com/uraimo/run-on-arch-action)
 - [Generate a table of contents](https://github.com/technote-space/toc-generator)
 - [Automatically add Label or Assignee to an Issue](https://github.com/Naturalclar/issue-action)
+- [Label and display the top-upvoted issues and pull requests](https://github.com/rickstaa/top-issues-action)
 - [Action to send LGTM reaction as image or GIF when we say lgtm](https://github.com/micnncim/action-lgtm-reaction)
 - [Generate build numbers across multiple scopes](https://github.com/zyborg/gh-action-buildnum)
 - [Publish GitHub release artifacts](https://github.com/skx/github-action-publish-binaries)


### PR DESCRIPTION
A simple GitHub action that allows you to label and display the top issues/bugs/feature requests and PRs. I created this action for my own workflow. Feel free to reject if you don't think the action is useful for other people.