### PR TITLE
Add slackapi/slack-github-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Send an Embed Message to Discord](https://github.com/sarisia/actions-status-discord)
 - [Keep Your PRs in Sync With Teamwork Tasks](https://github.com/Teamwork/github-sync)
 - [Send Microsoft Teams Notification](https://github.com/opsless/ms-teams-github-actions)
+- [Send Slack message via SlackAPI](https://github.com/slackapi/slack-github-action)
 
 ### Deployment
 


### PR DESCRIPTION
Adds https://github.com/slackapi/slack-github-action the action to send message to Slack via SlackAPI.