### PR TITLE
Add srvaroa/labeler to GitHub Tools and Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Herald Rules for GitHub: Add Subscribers, Assignees, Labels, and More to Your PR](https://github.com/gagoar/use-herald-action)
 - [GitHub Codeowners Validator](https://github.com/mszostok/codeowners-validator) - Ensures the correctness of your GitHub CODEOWNERS file. It supports public and private GitHub repositories and also GitHub Enterprise installations.
 - [Copybara Action](https://github.com/olivr/copybara-action) - Move and transform code between repositories (ideal to maintain several repos from one monorepo).
+- [Manage labels with configurable rules in Pull Requests and Issues](https://github.com/srvaroa/labeler/) - Action based on configurable rules that match on properties of Pull Requests and Issues to assign/remove labels automatically.
 
 ### Collection of Actions
 


### PR DESCRIPTION
Add [srvaroa/labeler](https://github.com/srvaroa/labeler): a label manager based on configurable rules that match on properties of Pull Requests and Issues to assign/remove labels