### PR TITLE
Adds a link to the Vale Action in the Linting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run sqlcheck on the PR to identifies anti-patterns in SQL queries](https://github.com/yokawasa/action-sqlcheck)
 - [Validate Fastlane Supply Metadata Against the Play Store Guidelines](https://github.com/ashutoshgngwr/validate-fastlane-supply-metadata)
 - [Run Golint to lint your Golang code](https://github.com/Jerome1337/golint-action)
+- [Vale: A syntax-aware linter for prose](https://github.com/errata-ai/vale-action)
 
 #### Security
 


### PR DESCRIPTION
[Vale](https://vale.sh/) is an open-source, command-line tool that allows you to create and enforce style rules. The [Vale Action](https://github.com/errata-ai/vale-action) can be used to install, manage, and run Vale for pull requests.