### PR TITLE
Add VanOns/get-merged-pull-requests-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
+- [Get Merged Pull Requests](https://github.com/VanOns/get-merged-pull-requests-action) - GitHub action that compares 2 tags and retrieves all pull requests merged between them.
 
 ### GitHub Pages
 


### PR DESCRIPTION
This is a GitHub action that compares 2 tags and retrieves the merged pull requests between them. It then returns them to be used by other actions in a workflow. Example use case: when running a deploy, send a Slack notification and include all merged pull requests.