### PR TITLE
Fix awesome-lint CI workflow in general and current violations in particular

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,5 +5,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: max/awesome-lint@v2.0.0
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: npx awesome-lint

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Paths Filter](https://github.com/dorny/paths-filter) - Conditionally run actions based on files modified by PR, feature branch or pushed commits.
 - [Minisauras](https://github.com/TeamTigers/minisauras) -  Pulls all the JavaScript and CSS files from your base branch, minify them and creates a pull-request with a new branch.
 - [Website to GIF](https://github.com/PabloLec/website-to-gif) - Turn any webpage into a GIF to display on your README, docs, etc.
-- [Interactive Inputs - Runtime workflow inputs](https://github.com/boasiHQ/interactive-inputs) - Add dynamic inputs at runtime for your GitHub Actions workflows
+- [Interactive Inputs - Runtime workflow inputs](https://github.com/boasiHQ/interactive-inputs) - Add dynamic inputs at runtime for your GitHub Actions workflows.
 
 #### Environments
 


### PR DESCRIPTION
* use [awesome-lint directly](https://github.com/sindresorhus/awesome-lint/tree/main?tab=readme-ov-file#continuous-integration) instead of [deprecated](https://github.com/max/awesome-lint/issues/7) `max/awesome-lint@2.0.0` to make CI work in general again
* add punctuation (full stop) in line 234 of README to fix current style violations pointed out by awesome-lint