### PR TITLE
Add CICube

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
 - [Check bundlephobia](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website and rejects PR on threshold surpassed.
+- [CICube](https:/cicube.io) - Optimize your GitHub Actions with Insightful Analysis
 
 ### Pull Requests
 


### PR DESCRIPTION
 This adds https://cicube.io, an GitHub Actions monitoring/dashboard/analyze tool.