### PR TITLE
Add entry for Baler, a bad link reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
 - [Check bundlephobia](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website and rejects PR on threshold surpassed.
+- [Test URLs in Markdown files and open issues for problems](https://github.com/caltechlibrary/baler)
 
 ### Pull Requests
 


### PR DESCRIPTION
This is a proposal to an entry for Baler (**ba**d **l**ink report**er**), a GitHub Action that tests the URLs inside Markdown files of your GitHub repository. If any of them are invalid, Baler automatically opens a GitHub issue to report the problem(s).