### PR TITLE
Add cursor-lint-action to Static Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 
 ### Static Analysis
 
+- [Lint Cursor AI Rules](https://github.com/cursorrulespacks/cursor-lint-action) - Lint .mdc and .cursorrules files, catching broken frontmatter and missing fields that silently break AI code generation.
 - [PHPStan Static code analyzer Action](https://github.com/OskarStark/phpstan-ga)
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)


### PR DESCRIPTION
Adds [cursor-lint-action](https://github.com/cursorrulespacks/cursor-lint-action) to the Static Analysis section.

It lints Cursor AI rule files (.mdc and .cursorrules), catching broken YAML frontmatter, missing `alwaysApply` fields, and other issues that silently break AI code generation in [Cursor](https://cursor.com).

Usage:
```yaml
- uses: cursorrulespacks/cursor-lint-action@v1
```

Also available as an [npm package](https://www.npmjs.com/package/cursor-lint) and [VS Code extension](https://open-vsx.org/extension/nedcodes/cursor-lint).