### PR TITLE
Add notify-cascade to Notifications and Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 
 - [Send a Discord notification](https://github.com/Ilshidur/action-discord)
 - [Post a Slack message as a bot](https://github.com/pullreminders/slack-action)
+- [Notify Cascade — send to Slack, email (SMTP), and custom webhooks in one step](https://github.com/kai-learner/notify-cascade)
 - [Send an SMS from GitHub Actions using Nexmo](https://github.com/nexmo-community/nexmo-sms-action)
 - [Send an SMS from GitHub Actions using Clockworksms](https://github.com/bharathvaj1995/clockwork-sms-action)
 - [Send a Telegram Message](https://github.com/appleboy/telegram-action)


### PR DESCRIPTION
## What is notify-cascade?

[notify-cascade](https://github.com/kai-learner/notify-cascade) is a GitHub Action that sends notifications to **Slack**, **email (SMTP)**, and **custom HTTP webhooks** — all in one step, fired in parallel.

### Why it's a good addition

Most teams need to notify 2-3 channels on CI events. Today they chain separate actions for each one. notify-cascade handles all three in a single step with a simple YAML config:

```yaml
- uses: kai-learner/notify-cascade@v1
  with:
    message: 'Deploy to production succeeded 🚀'
    slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
    email-to: team@example.com
    smtp-host: smtp.gmail.com
    smtp-user: ${{ secrets.SMTP_USER }}
    smtp-password: ${{ secrets.SMTP_PASSWORD }}
    webhook-url: ${{ secrets.OPS_WEBHOOK }}
```

- ✅ All channels fire in parallel (non-blocking)
- ✅ Per-channel status outputs (sent / skipped / failed)
- ✅ Rich Slack block-kit messages with repo/run context
- ✅ HTML + plain-text email, customisable subject
- ✅ Custom webhook headers and body templates with `{{message}}`, `{{repository}}`, etc.
- ✅ 10 unit tests, CI on Node 20 + 22, MIT license, node20 runtime

It fits under **Notifications and Messages** alongside the existing Slack and email actions.