### PR TITLE
Add changelog-action to GitHub Tools and Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Lock Closed Issues and Pull Requests after a Period of Inactivity](https://github.com/dessant/lock-threads)
 - [Get Commit Difference Count Between Two Branches](https://github.com/jessicalostinspace/commit-difference-action)
 - [Generate Release Notes Based on Git References](https://github.com/metcalfc/changelog-generator)
+- [Generate Beautiful Changelogs from Conventional Commits](https://github.com/NikitaDmitrieff/changelog-action) - Automatically generate formatted changelogs grouped by commit type, with support for custom templates.
 - [Enforce Policies on GitHub Repositories and Commits](https://github.com/talos-systems/conform)
 - [Auto Label Issue Based on Issue Description](https://github.com/Renato66/auto-label)
 - [Update Configured GitHub Actions to the Latest Versions](https://github.com/fabasoad/ghacu)


### PR DESCRIPTION
## Summary

- Adds [changelog-action](https://github.com/NikitaDmitrieff/changelog-action) to the **GitHub Tools and Management** section.
- This GitHub Action generates beautiful changelogs from conventional commits, grouping entries by commit type (features, fixes, etc.) with support for custom templates.
- Placed alongside the existing changelog-generator entry for discoverability.

## Checklist

- [x] Entry follows the existing list format
- [x] Link points to a valid, public GitHub repository
- [x] Description is concise and accurate
- [x] Placed in the appropriate section