### PR TITLE
Add EkLine to Linting section - documentation quality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run sqlcheck on the PR to identifies anti-patterns in SQL queries](https://github.com/yokawasa/action-sqlcheck)
 - [Validate Fastlane Supply Metadata Against the Play Store Guidelines](https://github.com/ashutoshgngwr/validate-fastlane-supply-metadata)
 - [Run Golint to lint your Golang code](https://github.com/Jerome1337/golint-action)
+- [EkLine - Documentation quality checks on PRs](https://github.com/ekline-io/ekline-github-action)
 
 #### Security
 


### PR DESCRIPTION
Adding EkLine's GitHub Action to the Linting section.

**ekline-github-action** runs documentation quality checks on pull requests:
- Style guide enforcement (active voice, terminology, structure)
- Broken link detection
- Inline PR review comments with one-click suggestions

Free for public repositories.

- Repository: https://github.com/ekline-io/ekline-github-action
- Marketplace: https://github.com/marketplace/actions/ekline-docs-review
