### PR TITLE
Add GitHub Actions Cost Calculator to Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Minisauras](https://github.com/TeamTigers/minisauras) -  Pulls all the JavaScript and CSS files from your base branch, minify them and creates a pull-request with a new branch.
 - [Website to GIF](https://github.com/PabloLec/website-to-gif) - Turn any webpage into a GIF to display on your README, docs, etc.
 - [Interactive Inputs - Runtime workflow inputs](https://github.com/boasiHQ/interactive-inputs) - Add dynamic inputs at runtime for your GitHub Actions workflows
+- [GitHub Actions Cost Calculator](https://githubactionscost.online) - Estimate your CI/CD billing locally in your browser using OS multipliers.
 
 #### Environments
 


### PR DESCRIPTION
Added a new utility to the list.

Tool: GitHub Actions Cost Calculator
Link: https://githubactionscost.online

This is a free, client-side calculator to help developers estimate their monthly GitHub Actions billing based on OS multipliers. It runs entirely locally for maximum privacy.

I have ensured the entry is at the bottom of the category, uses title casing, and has no trailing whitespaces as per the contributing guidelines.