### PR TITLE
Add PR-Sentry to Pull Requests category

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
+- [PR-Sentry](https://github.com/ebuodinde/pr-sentry) - A zero-nitpick GitHub Action to block AI-generated PR slop and check security patterns.
 
 ### GitHub Pages
 


### PR DESCRIPTION
Added PR-Sentry to the Pull Requests section. It's a zero-nitpick GitHub Action that calculates a local slop score to block AI-generated PR spam and reports runtime/security issues.