### PR TITLE
Add axle — WCAG accessibility compliance CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)
 - [Run tfsec, with reviewdog output on the PR](https://github.com/reviewdog/action-tfsec)
+- [axle](https://github.com/asafamos/axle-action) — Scan every PR for WCAG 2.1 / 2.2 AA accessibility violations with axe-core, generate AI code-fix suggestions with Claude Sonnet, post inline comments, block merge on regressions. Free tier. ([Marketplace listing](https://github.com/marketplace/actions/axle-accessibility-compliance-ci))
 
 #### Testing
 


### PR DESCRIPTION
axle is a GitHub Action that scans every PR for WCAG 2.1 / 2.2 AA accessibility violations using axe-core, and generates surgical AI code-fix suggestions with Claude. Posts inline comments, blocks merge on regressions, uploads JSON + markdown artifacts.

Why add it:
- No overlay widgets (FTC fined accessiBe $1M in Jan 2025 for that category)
- Free tier with a real feature set (not a gated demo)
- Already live on Marketplace (v1.0.0, MIT license)
- Hebrew and EU-wide accessibility statement generator as a free lead tool

Demo & docs: https://axle-iota.vercel.app