### PR TITLE
Add axle (accessibility compliance CI) under Static Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)
 - [Run tfsec, with reviewdog output on the PR](https://github.com/reviewdog/action-tfsec)
+- [axle - Accessibility Compliance CI. Scans every PR for WCAG 2.1/2.2 AA violations and generates source-code fix diffs via Claude.](https://github.com/asafamos/axle-action)
 
 #### Testing
 


### PR DESCRIPTION
Adds [axle](https://github.com/asafamos/axle-action) to the Static Analysis section.

**What it does:** scans every pull request for WCAG 2.1 / 2.2 AA accessibility violations using axe-core 4.11 and, optionally, generates source-code fix diffs via Claude Sonnet. Posts a sticky PR comment with findings; exits non-zero at a configurable severity threshold so you can require it as a merge check.

**Why this list / this section:** it's a static analyzer for HTML/CSS accessibility, same category as the PHPStan / tfsec / GraphQL Inspector entries right above it. Composite Action, published to GitHub Marketplace as `axle-accessibility-compliance-ci`.

**Differentiator from "accessibility overlay" widgets (which don't belong on this list):** axle never injects runtime JavaScript. It scans, suggests source-code diffs in the PR comment, and lets your merge button decide. Overlay widgets were the subject of the $1M FTC settlement against accessiBe in January 2025.

Happy to adjust wording / placement if another section fits better.