### PR TITLE
Update axle entry: new Marketplace title + Section 508 keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)
 - [Run tfsec, with reviewdog output on the PR](https://github.com/reviewdog/action-tfsec)
-- [axle - Accessibility Compliance CI. Scans every PR for WCAG 2.1/2.2 AA violations and generates source-code fix diffs via Claude.](https://github.com/asafamos/axle-action)
+- [axle — a11y / WCAG Accessibility CI. Scans every PR for WCAG 2.1/2.2 AA violations with axe-core and proposes source-code fix diffs via Claude. Built for EAA 2025, ADA, Section 508.](https://github.com/marketplace/actions/axle-a11y-wcag-accessibility-ci)
 
 #### Testing
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)
 - [Run tfsec, with reviewdog output on the PR](https://github.com/reviewdog/action-tfsec)
+- [axle - Accessibility Compliance CI. Scans every PR for WCAG 2.1/2.2 AA violations and generates source-code fix diffs via Claude.](https://github.com/asafamos/axle-action)
 
 #### Testing
 


### PR DESCRIPTION
Hi 👋 — I&apos;m the maintainer of the axle GitHub Action that&apos;s already listed under `Static Analysis` (line 265).

The Action's Marketplace listing was renamed on 26 April 2026 from `axle — Accessibility Compliance CI` to `axle — a11y / WCAG Accessibility CI` so it shows up under the `a11y` Marketplace search (it didn&apos;t before). This PR updates the existing list entry to:

1. Match the new Marketplace title.
2. Point the link at the Marketplace listing URL (where users actually go to install) instead of the source repo.
3. Mention `Section 508` alongside `WCAG` for searchability.

No new entry — same line, same position, just updated.

Thanks for maintaining the list!