### PR TITLE
Add ci-doctor under Linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run sqlcheck on the PR to identifies anti-patterns in SQL queries](https://github.com/yokawasa/action-sqlcheck)
 - [Validate Fastlane Supply Metadata Against the Play Store Guidelines](https://github.com/ashutoshgngwr/validate-fastlane-supply-metadata)
 - [Run Golint to lint your Golang code](https://github.com/Jerome1337/golint-action)
+- [ci-doctor - Audit GitHub Actions workflows for waste, cost, and security gaps. Auto-fix mode and SARIF output for Code Scanning.](https://github.com/depmedicdev-byte/ci-doctor)
 
 #### Security
 


### PR DESCRIPTION
Adds ci-doctor under the Linting subsection.

ci-doctor is a free MIT linter for GitHub Actions workflows. 14 rules across cost, security, and maintenance categories. Includes `--fix` mode that auto-applies safe permissions/concurrency/timeout/retention fixes in place, and `--sarif` output for upload to GitHub Code Scanning. Ships as both an npm CLI (`npx ci-doctor`) and a GitHub Action.

Repo: https://github.com/depmedicdev-byte/ci-doctor
npm: https://www.npmjs.com/package/ci-doctor

Insertion is at the end of the Linting subsection (after the existing Golint entry), per the contributing guidelines.