### PR TITLE
Add ci-doctor (CI cost+security audit) and pin-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 ### Cheat Sheet
 
 - [GitHub Actions Branding Cheat Sheet](https://haya14busa.github.io/github-action-brandings/)
+- [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audit a workflow for cost waste, security gaps, and reliability issues. 16 rules, SARIF + PR comment via [ci-doctor-action](https://github.com/depmedicdev-byte/ci-doctor-action).
+- [pin-actions](https://github.com/depmedicdev-byte/pin-actions) - One-shot CLI that pins every `uses:` reference in your workflows to a SHA.
 
 ## Tutorials
 


### PR DESCRIPTION
### What this adds

> - [ci-doctor](https://github.com/depmedicdev-byte/ci-doctor) - Audit a workflow for cost waste, security gaps, and reliability issues. 16 rules, SARIF + PR comment via [ci-doctor-action](https://github.com/depmedicdev-byte/ci-doctor-action).
>
> - [pin-actions](https://github.com/depmedicdev-byte/pin-actions) - One-shot CLI that pins every `uses:` reference in your workflows to a SHA.

### Why

depmedic ships a family of CI cost+security auditors covering GitHub, GitLab, Bitbucket, Azure Pipelines, and CircleCI. Each is a single-binary `npx` invocation, MIT, no telemetry, with SARIF + PR comment integration. They are well-tested (3-5 `node --test` suites each), versioned, and actively maintained.

### Conformance

- One line per entry in alphabetical order within the section
- Description starts with a verb (Audit / Audits)
- Trailing period on the description
- Link target is the canonical repo URL

Happy to adjust wording, ordering, or section placement; ping me on this PR.

---

If you'd rather decline, no hard feelings. Thanks for the list.