### PR TITLE
Add Shipcheck Repo Scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Snyk Test Action](https://github.com/snyk/actions)
 - [Manage Your GitHub Actions Secrets With A Simple CLI](https://github.com/unfor19/githubsecrets)
 - [SecretHub](https://github.com/secrethub/actions) - Have a single source of truth for your secrets and load them into GitHub Actions on demand.
-- [Shipcheck Repo Scanner](https://github.com/TateLyman/shipcheck-action) - Scan JavaScript, TypeScript, and MCP repos for release-readiness, secrets, webhook, database-rule, and deploy risks, with SARIF output.
+- [Shipcheck Repo Scanner](https://github.com/TateLyman/shipcheck-action) - Scan JavaScript, TypeScript, and MCP repos for release-readiness, secrets, webhook, database-rule, deploy, npm publish-token, and MCP metadata risks, with SARIF output.
 
 #### Code Coverage
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Snyk Test Action](https://github.com/snyk/actions)
 - [Manage Your GitHub Actions Secrets With A Simple CLI](https://github.com/unfor19/githubsecrets)
 - [SecretHub](https://github.com/secrethub/actions) - Have a single source of truth for your secrets and load them into GitHub Actions on demand.
+- [Shipcheck Repo Scanner](https://github.com/TateLyman/shipcheck-action) - Scan JavaScript and TypeScript repos for release-readiness, secrets, webhook, database-rule, and deploy risks.
 
 #### Code Coverage
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Snyk Test Action](https://github.com/snyk/actions)
 - [Manage Your GitHub Actions Secrets With A Simple CLI](https://github.com/unfor19/githubsecrets)
 - [SecretHub](https://github.com/secrethub/actions) - Have a single source of truth for your secrets and load them into GitHub Actions on demand.
-- [Shipcheck Repo Scanner](https://github.com/TateLyman/shipcheck-action) - Scan JavaScript and TypeScript repos for release-readiness, secrets, webhook, database-rule, and deploy risks.
+- [Shipcheck Repo Scanner](https://github.com/TateLyman/shipcheck-action) - Scan JavaScript, TypeScript, and MCP repos for release-readiness, secrets, webhook, database-rule, and deploy risks, with SARIF output.
 
 #### Code Coverage
 


### PR DESCRIPTION
Adds Shipcheck Repo Scanner to the Security section.

Repository link: https://github.com/TateLyman/shipcheck-action

Local note: awesome-lint currently reports existing upstream list issues unrelated to this one-line addition.