### PR TITLE
Add Tokenometer — LLM cost CLI + GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 
 ### Utility
 
+- [Tokenometer](https://github.com/faraa2m/tokenometer) - LLM token cost + latency CLI and GitHub Action. Posts a sticky PR comment with per-prompt token + dollar cost across Claude, GPT-4o, Gemini, Mistral, and Cohere, and fails the build when a configurable budget is exceeded.
 - [Setup `ssh-agent`](https://github.com/webfactory/ssh-agent) - Run `ssh-agent` with additional SSH keys to access private repositories.
 - [GitHub Actions Badges for your README](https://github.com/atrox/github-actions-badge)
 - [GitHub Actions for Python project with poetry](https://github.com/abatilo/actions-poetry)


### PR DESCRIPTION
Adds Tokenometer to the appropriate section.

**Tokenometer** — empirical LLM token-cost CLI + GitHub Action + VS Code / Cursor extension + Claude Code skill. Multi-provider (Claude, GPT-4o, Gemini, Mistral, Cohere), offline + empirical modes, CI cost-guardrail with sticky PR comments and budget gates.

- Repo: https://github.com/faraa2m/tokenometer
- npm: `npx tokenometer ./prompt.md --model claude-opus-4-7`
- GitHub Marketplace: https://github.com/marketplace/actions/tokenometer
- Live demo: https://tokenometer.vercel.app
- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=faraa2m.tokenometer-vscode

If the placement is in the wrong section happy to adjust.