### PR TITLE
Add Type/Test/Suppress Ratchet (zero-config quality-gate actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [GraphQL Inspector Action](https://github.com/kamilkisiela/graphql-inspector)
 - [PowerShell static analysis with PSScriptAnalyzer](https://github.com/devblackops/github-action-psscriptanalyzer)
 - [Run tfsec, with reviewdog output on the PR](https://github.com/reviewdog/action-tfsec)
+- [Type Ratchet: fail PRs that add type escape hatches (any, as any, @ts-ignore, type: ignore)](https://github.com/motchalini-llc/type-ratchet)
 
 #### Testing
 
@@ -276,6 +277,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Detect Flaky Tests with BuildPulse](https://github.com/Workshop64/buildpulse-action)
 - [Display Inline Code Annotations for Jest Tests](https://github.com/IgnusG/jest-report-action)
 - [Run Julia tests](https://github.com/julia-actions/julia-runtest)
+- [Test Ratchet: fail PRs that skip tests or sneak in .only](https://github.com/motchalini-llc/test-ratchet)
 
 #### Linting
 
@@ -309,6 +311,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Run sqlcheck on the PR to identifies anti-patterns in SQL queries](https://github.com/yokawasa/action-sqlcheck)
 - [Validate Fastlane Supply Metadata Against the Play Store Guidelines](https://github.com/ashutoshgngwr/validate-fastlane-supply-metadata)
 - [Run Golint to lint your Golang code](https://github.com/Jerome1337/golint-action)
+- [Suppress Ratchet: fail PRs that add linter-suppression comments (eslint-disable, noqa)](https://github.com/motchalini-llc/suppress-ratchet)
 
 #### Security
 


### PR DESCRIPTION
Adds the three `*-ratchet` actions — zero-config, zero-dependency PR gates that fail when "make CI green by silencing the tool" escapes increase (a baseline that can only tighten):

- **Type Ratchet** (Static Analysis): `any` / `as any` / `@ts-ignore` / `# type: ignore`
- **Test Ratchet** (Testing): skipped tests ratcheted, `.only` hard-forbidden
- **Suppress Ratchet** (Linting): `eslint-disable` / `biome-ignore` / `# noqa`

TypeScript & Python, MIT, published on the GitHub Marketplace. Live demo where a single "quick fix" PR trips all three gates with inline annotations: motchalini-llc/ratchet-demo#1

Disclosure: I'm the author of these actions.
