### PR TITLE
Add Lazaretto Scan (dependency malware scanner) to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories.
 - [Secrets Sync Action](https://github.com/google/secrets-sync-action) - Action syncs secrets across multiple repositories.
 - [Snyk Test Action](https://github.com/snyk/actions)
-- [Scan dependencies for malicious behavior before they merge](https://github.com/jamesdfinance-dev/lazaretto-scan-action) - Checks npm packages, repos, and skills against known-bad indicators and behavioral rules; posts a verdict comment on the PR and fails the build on a malicious verdict.
+- [Lazaretto Scan](https://github.com/jamesdfinance-dev/lazaretto-scan-action) - Fails the build when a pinned dependency is known malware. Checks `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml` against published advisories and posts the verdict as a PR comment; no API key required.
 - [Manage Your GitHub Actions Secrets With A Simple CLI](https://github.com/unfor19/githubsecrets)
 - [SecretHub](https://github.com/secrethub/actions) - Have a single source of truth for your secrets and load them into GitHub Actions on demand.
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Secret Spreader](https://github.com/webfactory/secret-spreader) - Not an action per se, but a tool to manage Actions Secrets across a list of repositories.
 - [Secrets Sync Action](https://github.com/google/secrets-sync-action) - Action syncs secrets across multiple repositories.
 - [Snyk Test Action](https://github.com/snyk/actions)
+- [Scan dependencies for malicious behavior before they merge](https://github.com/jamesdfinance-dev/lazaretto-scan-action) - Checks npm packages, repos, and skills against known-bad indicators and behavioral rules; posts a verdict comment on the PR and fails the build on a malicious verdict.
 - [Manage Your GitHub Actions Secrets With A Simple CLI](https://github.com/unfor19/githubsecrets)
 - [SecretHub](https://github.com/secrethub/actions) - Have a single source of truth for your secrets and load them into GitHub Actions on demand.
 


### PR DESCRIPTION
Adds [lazaretto-scan-action](https://github.com/jamesdfinance-dev/lazaretto-scan-action) under Community Resources -> Security.

It scans your npm packages, repos, or skills for malicious behavior (known-bad indicators refreshed daily plus deterministic behavioral rules), posts a verdict comment on the pull request, and fails the build on a malicious verdict. Open source (MIT), released, and documented with a quick start. Fits alongside the other dependency-security actions in that section.