### PR TITLE
Add Safe Site Preflight Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Audit a webpage with Google Chrome's Lighthouse tests](https://github.com/jakejarvis/lighthouse-action)
 - [Runs Lighthouse and posts results to PRs and Slack](https://github.com/foo-software/lighthouse-check-action)
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
+- [Safe Site Preflight](https://github.com/BabaVictim/website-repair-sprint) - Audits one public website with bounded, read-only launch-readiness checks and no token or install step.
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
 - [Check bundlephobia](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website and rejects PR on threshold surpassed.

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Audit a webpage with Google Chrome's Lighthouse tests](https://github.com/jakejarvis/lighthouse-action)
 - [Runs Lighthouse and posts results to PRs and Slack](https://github.com/foo-software/lighthouse-check-action)
 - [Run Lighthouse in CI using GitHub Actions](https://github.com/treosh/lighthouse-ci-action)
-- [Safe Site Preflight](https://github.com/BabaVictim/website-repair-sprint) - Audits one public website with bounded, read-only launch-readiness checks and no token or install step.
+- [Safe Site Preflight](https://github.com/BabaVictim/safe-site-preflight) - Audits one public website with bounded, read-only launch-readiness checks and no token or install step.
 - [Continuous Benchmarking and Benchmark Visualization for Go](https://github.com/bobheadxi/gobenchdata)
 - [Size Limit Action](https://github.com/andresz1/size-limit-action) - Comments cost comparison of your JS in PRs and rejects them if limit is exceeded.
 - [Check bundlephobia](https://github.com/carlesnunez/check-my-bundlephobia) - Comments new and modified package size according to bundlephobia.io website and rejects PR on threshold surpassed.


### PR DESCRIPTION
Adds Safe Site Preflight under Monitoring. This is a transparent self-submission.

Why it may be useful:
- Native Node 24 Action with zero runtime dependencies
- Audits one public HTTP(S) URL with strict request, timeout, body, and redirect bounds
- Rejects private/reserved targets and revalidates every redirect
- Requires no token, account, or install step
- Tested release tags v1 and v1.0.0

The change is one list entry and does not alter existing items.