### PR TITLE
Add App Dropper action for APK/IPA distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Deploy VS Code Extension to Visual Studio Marketplace or the Open VSX Registry](https://github.com/HaaLeo/publish-vscode-extension)
 - [Deploy a YouTube Video to Anchor.fm Podcast](https://github.com/Schrodinger-Hat/youtube-to-anchorfm)
 - [Deploy with AWS CodeDeploy](https://github.com/webfactory/create-aws-codedeploy-deployment)
+- [Upload APK/IPA builds to App Dropper](https://github.com/appdropper-io/upload-action)
 
 #### Docker
 


### PR DESCRIPTION
This PR adds [Upload to App Dropper](https://github.com/appdropper-io/upload-action) at the end of the Deployment section, a GitHub Action to upload APK/IPA builds to App Dropper and get a shareable install link, straight from CI.

Single suggestion, README.md only, formatted like neighboring entries.